### PR TITLE
Create new config loader

### DIFF
--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -8,7 +8,7 @@ def detect_configfile_path():
     candidates, and `None` if the list was exhausted, but no candidate config
     file exists.
 
-    For details, see :func:`load_config`.
+    For details, see :func:`load_config_from_file`.
     """
     app = "dwave"
     author = "dwavesystem"
@@ -35,7 +35,7 @@ def detect_configfile_path():
     return None
 
 
-def load_config(filename=None):
+def load_config_from_file(filename=None):
     """Load D-Wave cloud client configuration from `filename`.
 
     The format of the config file is the standard Windows INI-like format,
@@ -104,7 +104,7 @@ def load_config(filename=None):
 
 def load_profile(name, filename=None):
     """Load profile with `name` from `filename` config file."""
-    return load_config(filename)[name]
+    return load_config_from_file(filename)[name]
 
 
 def load_configuration(key=None):

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -144,7 +144,7 @@ def load_config(config_file=None, profile=None, client=None,
     }
 
 
-def load_configuration(key=None):
+def legacy_load_config(key=None):
     """Load the configured URLs and token for the SAPI server.
 
     First, this method tries to read from environment variables.

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -90,7 +90,7 @@ def load_config(filename=None):
 
 def load_profile(name, filename=None):
     """Load profile with `name` from `filename` config file."""
-    return load_config(filename).get(name, None)
+    return load_config(filename)[name]
 
 
 def load_configuration(key=None):

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -12,19 +12,26 @@ def detect_configfile_path():
     """
     app = "dwave"
     author = "dwavesystem"
-    filename = "config"
+    filename = "dwave.conf"
 
-    candidates = ["{}.{}".format(app, filename)]
+    # look for `./dwave.conf`
+    candidates = ["."]
+
+    # then for something like `~/.config/dwave/dwave.conf`
     candidates.append(homebase.user_config_dir(
         app_author=author, app_name=app, roaming=False,
         use_virtualenv=False, create=False))
+
+    # and finally for e.g. `/etc/dwave/dwave.conf`
     candidates.extend(homebase.site_config_dir_list(
         app_author=author, app_name=app,
         use_virtualenv=False, create=False))
+
     for base in candidates:
         path = os.path.join(base, filename)
         if os.path.exists(path):
             return path
+
     return None
 
 
@@ -59,19 +66,20 @@ def load_config(filename=None):
         filename (str, default=None):
             D-Wave cloud client configuration file location.
 
-            If unspecified, config file is searched for in current directory,
-            then in user-local config dir, and then in all system-wide config
-            dirs. For example, on Unix, we try to load the config from these
-            paths (in order) and possibly others (depending on Unix flavour)::
+            If unspecified, config file named ``dwave.conf`` is searched for in
+            the current directory, then in the user-local config dir, and then
+            in all system-wide config dirs. For example, on Unix, we try to load
+            the config from these paths (in order) and possibly others
+            (depending on your Unix flavour)::
 
-                ./dwave.config
-                ~/.config/dwave/config
-                /usr/local/share/dwave/config
-                /usr/share/dwave/config
+                ./dwave.conf
+                ~/.config/dwave/dwave.conf
+                /usr/local/share/dwave/dwave.conf
+                /usr/share/dwave/dwave.conf
 
             On Windows, config file should be located in:
-            ``C:\\Users\\<username>\\AppData\\Local\\dwave\\client\\config``,
-            and on MacOS in: `~/Library/Application Support/dwave/config`.
+            ``C:\\Users\\<username>\\AppData\\Local\\dwave\\client\\dwave.conf``,
+            and on MacOS in: ``~/Library/Application Support/dwave/dwave.conf``.
             For details on user/system config paths see homebase_.
 
             .. _homebase: https://github.com/dwavesystems/homebase

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -111,7 +111,7 @@ def load_profile(name, filename=None):
     return load_config_from_file(filename)[name]
 
 
-def load_config(config_file=None, profile=None,
+def load_config(config_file=None, profile=None, client=None,
                 endpoint=None, token=None, solver=None, proxy=None):
     """Load config. Explicitly supplied values override environment values, and
     environment values override config file values.
@@ -138,6 +138,7 @@ def load_config(config_file=None, profile=None,
     return {
         'endpoint': endpoint or os.getenv("DWAVE_API_ENDPOINT", section.get('endpoint')),
         'token': token or os.getenv("DWAVE_API_TOKEN", section.get('token')),
+        'client': client or os.getenv("DWAVE_API_CLIENT", section.get('client')),
         'solver': solver or os.getenv("DWAVE_API_SOLVER", section.get('solver')),
         'proxy': proxy or os.getenv("DWAVE_API_PROXY", section.get('proxy')),
     }

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -84,10 +84,13 @@ def load_config(filename=None):
     if filename is None:
         filename = detect_configfile_path()
         if not filename:
-            raise IOError("Config filename not given, and could not be detected")
+            raise ValueError("Config filename not given, and could not be detected")
 
     config = configparser.ConfigParser(default_section="defaults")
-    config.read(filename)
+    if not config.read(filename):
+        raise ValueError("Failed to parse the config file "\
+                         "given or detected: {}".format(filename))
+
     return config
 
 

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -10,13 +10,16 @@ def detect_configfile_path():
 
     For details, see :func:`load_config`.
     """
+    app = "dwave"
+    author = "dwavesystem"
     filename = "config"
-    candidates = [filename]
+
+    candidates = ["{}.{}".format(app, filename)]
     candidates.append(homebase.user_config_dir(
-        app_author="dwavesystem", app_name="dwave", roaming=False, 
+        app_author=author, app_name=app, roaming=False,
         use_virtualenv=False, create=False))
     candidates.extend(homebase.site_config_dir_list(
-        app_author="dwavesystem", app_name="dwave",
+        app_author=author, app_name=app,
         use_virtualenv=False, create=False))
     for base in candidates:
         path = os.path.join(base, filename)
@@ -56,12 +59,12 @@ def load_config(filename=None):
         filename (str, default=None):
             D-Wave cloud client configuration file location.
 
-            If unspecified, config file is searched for current directory, then
-            in user-local config dir, and then in all system-wide config dirs.
-            For example, on Unix, we try to load the config from these paths
-            (in order)::
+            If unspecified, config file is searched for in current directory,
+            then in user-local config dir, and then in all system-wide config
+            dirs. For example, on Unix, we try to load the config from these
+            paths (in order) and possibly others (depending on Unix flavour)::
 
-                ./config
+                ./dwave.config
                 ~/.config/dwave/config
                 /usr/local/share/dwave/config
                 /usr/share/dwave/config
@@ -81,7 +84,7 @@ def load_config(filename=None):
     if filename is None:
         filename = detect_configfile_path()
         if not filename:
-            raise IOError("Config filename not given, but could not be detected")
+            raise IOError("Config filename not given, and could not be detected")
 
     config = configparser.ConfigParser(default_section="defaults")
     config.read(filename)

--- a/dwave/cloud/qpu/client.py
+++ b/dwave/cloud/qpu/client.py
@@ -25,9 +25,9 @@ class Client(object):
     Connect to a SAPI server to expose the solvers that the server advertises.
 
     Args:
-        url (str): URL of the SAPI server.
+        endpoint (str): solver API endpoint URL
         token (str): Authentication token from the SAPI server.
-        proxies (dict): Mapping from the connection scheme (http[s]) to the proxy server address.
+        proxy (str): Proxy URL to be used for accessing the D-Wave API
         permissive_ssl (boolean; false by default): Disables SSL verification.
     """
 
@@ -52,7 +52,7 @@ class Client(object):
     _LOAD_THREAD_COUNT = 5
 
 
-    def __init__(self, url=None, token=None, proxies=None, permissive_ssl=False):
+    def __init__(self, endpoint=None, token=None, proxy=None, permissive_ssl=False):
         """To setup the connection a pipeline of queues/workers is constructed.
 
         There are five interations with the server the connection manages:
@@ -70,16 +70,16 @@ class Client(object):
         # missing, try the configuration function
         self.default_solver = None
         if token is None:
-            url, token, proxies, self.default_solver = load_configuration(url)
-        _LOGGER.debug("Creating a connection to SAPI server: %s", url)
+            endpoint, token, proxy, self.default_solver = load_configuration()
+        _LOGGER.debug("Creating a connection to SAPI server: %s", endpoint)
 
-        self.base_url = url
+        self.base_url = endpoint
         self.token = token
 
         # Create a :mod:`requests` session. `requests` will manage our url parsing, https, etc.
         self.session = requests.Session()
         self.session.headers.update({'X-Auth-Token': self.token})
-        self.session.proxies = proxies
+        self.session.proxies = {'http': proxy, 'https': proxy}
         if permissive_ssl:
             self.session.verify = False
 

--- a/dwave/cloud/qpu/client.py
+++ b/dwave/cloud/qpu/client.py
@@ -52,7 +52,7 @@ class Client(object):
     _LOAD_THREAD_COUNT = 5
 
 
-    def __init__(self, endpoint=None, token=None, proxy=None, permissive_ssl=False):
+    def __init__(self, endpoint=None, token=None, proxy=None, permissive_ssl=False, profile=None):
         """To setup the connection a pipeline of queues/workers is constructed.
 
         There are five interations with the server the connection manages:
@@ -70,7 +70,7 @@ class Client(object):
         # missing, try the configuration function
         self.default_solver = None
         if token is None:
-            endpoint, token, proxy, self.default_solver = load_configuration()
+            endpoint, token, proxy, self.default_solver = load_configuration(profile)
         _LOGGER.debug("Creating a connection to SAPI server: %s", endpoint)
 
         self.base_url = endpoint

--- a/dwave/cloud/qpu/client.py
+++ b/dwave/cloud/qpu/client.py
@@ -12,7 +12,7 @@ from itertools import chain
 from six.moves import queue, range
 
 from dwave.cloud.exceptions import *
-from dwave.cloud.config import load_configuration
+from dwave.cloud.config import legacy_load_config
 from dwave.cloud.qpu.solver import Solver
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ class Client(object):
         # missing, try the configuration function
         self.default_solver = None
         if token is None:
-            endpoint, token, proxy, self.default_solver = load_configuration(profile)
+            endpoint, token, proxy, self.default_solver = legacy_load_config(profile)
         _LOGGER.debug("Creating a connection to SAPI server: %s", endpoint)
 
         self.base_url = endpoint

--- a/dwave/cloud/qpu/client.py
+++ b/dwave/cloud/qpu/client.py
@@ -12,7 +12,7 @@ from itertools import chain
 from six.moves import queue, range
 
 from dwave.cloud.exceptions import *
-from dwave.cloud.config import legacy_load_config
+from dwave.cloud.config import load_config, legacy_load_config
 from dwave.cloud.qpu.solver import Solver
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,7 +52,8 @@ class Client(object):
     _LOAD_THREAD_COUNT = 5
 
 
-    def __init__(self, endpoint=None, token=None, proxy=None, permissive_ssl=False, profile=None):
+    def __init__(self, endpoint=None, token=None, proxy=None, permissive_ssl=False,
+                 profile=None, solver=None):
         """To setup the connection a pipeline of queues/workers is constructed.
 
         There are five interations with the server the connection manages:
@@ -66,20 +67,33 @@ class Client(object):
         performed by asynchronously workers. For 2, 3, and 5 the workers gather
         tasks in batches.
         """
-        # Use configuration from parameters passed, if parts are
-        # missing, try the configuration function
-        self.default_solver = None
-        if token is None:
-            endpoint, token, proxy, self.default_solver = legacy_load_config(profile)
-        _LOGGER.debug("Creating a connection to SAPI server: %s", endpoint)
 
-        self.base_url = endpoint
-        self.token = token
+        # load configuration from `dwave.conf`, but failback to legacy `.dwrc`
+        try:
+            config = load_config(
+                config_file=None, client=None, profile=profile,
+                endpoint=endpoint, token=token, solver=solver, proxy=proxy)
+        except ValueError:
+            config = dict(endpoint=endpoint, token=token, proxy=proxy, solver=solver)
+        #print("my config: %r" % config)
+        # TODO: FIX: legacy config loading is broken in so many ways
+        if config.get('token') is None:
+            _endpoint, _token, _proxy, _solver = legacy_load_config(profile)
+            config = dict(endpoint=_endpoint, token=_token, proxy=_proxy, solver=_solver)
+
+        if 'endpoint' not in config or 'token' not in config:
+            raise ValueError("Endpoint URL and/or token not defined")
+
+        _LOGGER.debug("Creating a client with params: %r", config)
+
+        self.base_url = config['endpoint']
+        self.token = config['token']
+        self.default_solver = config.get('solver')
 
         # Create a :mod:`requests` session. `requests` will manage our url parsing, https, etc.
         self.session = requests.Session()
         self.session.headers.update({'X-Auth-Token': self.token})
-        self.session.proxies = {'http': proxy, 'https': proxy}
+        self.session.proxies = {'http': config.get('proxy'), 'https': config.get('proxy')}
         if permissive_ssl:
             self.session.verify = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+six>=1.10
 requests>=2.18
+homebase>=1.0.0
 requests_mock
 mock
 numpy
-six==1.10
 coverage
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = ['requests>=2.18', 'six>=1.10']
 
 extras_require = {
     'test': ['requests_mock', 'mock', 'numpy'],
-    ':python_version == "2.7"': ['futures']
+    ':python_version == "2.7"': ['futures', 'configparser']
 }
 
 # Only include packages under the 'dwave' namespace. Do not include tests,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,13 +7,13 @@ from __future__ import absolute_import
 
 import unittest
 
-from dwave.cloud.config import load_configuration
+from dwave.cloud.config import legacy_load_config
 from dwave.cloud.qpu import Client
 from dwave.cloud.exceptions import SolverAuthenticationError
 
 
 try:
-    config_url, config_token, _, config_solver = load_configuration()
+    config_url, config_token, _, config_solver = legacy_load_config()
     if None in [config_url, config_token, config_solver]:
         raise ValueError()
     skip_live = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ except ImportError:
     configparser_open_namespace = "backports.configparser.open"
 
 
-from dwave.cloud.config import detect_configfile_path, load_config, load_profile
+from dwave.cloud.config import detect_configfile_path, load_config_from_file, load_profile
 
 
 class TestConfig(unittest.TestCase):
@@ -56,17 +56,17 @@ class TestConfig(unittest.TestCase):
 
     def test_config_load(self):
         with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):
-            config = load_config(filename="filename")
+            config = load_config_from_file(filename="filename")
             self.assertEqual(config.sections(), ['dw2000', 'software', 'alpha'])
             self.assertEqual(config['dw2000']['client'], 'qpu')
             self.assertEqual(config['software']['client'], 'sw')
 
     def test_no_config_detected(self):
         with mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None):
-            self.assertRaises(ValueError, load_config)
+            self.assertRaises(ValueError, load_config_from_file)
 
     def test_invalid_filename_given(self):
-        self.assertRaises(ValueError, load_config, filename='/path/to/non/existing/config')
+        self.assertRaises(ValueError, load_config_from_file, filename='/path/to/non/existing/config')
 
     def test_config_load_profile(self):
         with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,3 +58,9 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.sections(), ['dw2000', 'software', 'alpha'])
             self.assertEqual(config['dw2000']['client'], 'qpu')
             self.assertEqual(config['software']['client'], 'sw')
+
+    def test_config_load_profile(self):
+        with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):
+            profile = load_profile(name="alpha", filename="filename")
+            self.assertEqual(profile['token'], 'alpha-token')
+            self.assertRaises(KeyError, load_profile, name="non-existing-section", filename="filename")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import os
 import unittest
 import textwrap
 
@@ -71,3 +72,20 @@ class TestConfig(unittest.TestCase):
             profile = load_profile(name="alpha", filename="filename")
             self.assertEqual(profile['token'], 'alpha-token')
             self.assertRaises(KeyError, load_profile, name="non-existing-section", filename="filename")
+
+    def test_config_file_detection_cwd(self):
+        configpath = "./dwave.conf"
+        with mock.patch("os.path.exists", lambda path: path == configpath):
+            self.assertEqual(detect_configfile_path(), configpath)
+
+    def test_config_file_detection_user(self):
+        # assume Unix, XDG Base spec
+        configpath = os.path.expanduser("~/.config/dwave/dwave.conf")
+        with mock.patch("os.path.exists", lambda path: path == configpath):
+            self.assertEqual(detect_configfile_path(), configpath)
+
+    def test_config_file_detection_system(self):
+        # assume Unix, XDG Base spec
+        configpath = "/etc/xdg/dwave/dwave.conf"
+        with mock.patch("os.path.exists", lambda path: path == configpath):
+            self.assertEqual(detect_configfile_path(), configpath)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, print_function
 import os
 import sys
 import unittest
-import textwrap
+import configparser
+
+from functools import partial
 
 try:
     # python 3
@@ -29,7 +31,8 @@ except ImportError:
     configparser_open_namespace = "backports.configparser.open"
 
 
-from dwave.cloud.config import detect_configfile_path, load_config_from_file, load_profile
+from dwave.cloud.config import (
+    detect_configfile_path, load_config_from_file, load_profile, load_config)
 
 
 class TestConfig(unittest.TestCase):
@@ -54,7 +57,12 @@ class TestConfig(unittest.TestCase):
         token = alpha-token
     """
 
-    def test_config_load(self):
+    def parse_config_string(self, text):
+        config = configparser.ConfigParser(default_section="defaults")
+        config.read_string(text)
+        return dict(config)
+
+    def test_config_load_from_file(self):
         with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):
             config = load_config_from_file(filename="filename")
             self.assertEqual(config.sections(), ['dw2000', 'software', 'alpha'])
@@ -106,3 +114,53 @@ class TestConfig(unittest.TestCase):
     def test_config_file_detection_nonexisting(self):
         with mock.patch("os.path.exists", lambda path: False):
             self.assertEqual(detect_configfile_path(), None)
+
+
+    def _assert_config_valid(self, config):
+        # profile is loaded
+        self.assertEqual(config['endpoint'], "https://url.to.alpha/api")
+        # default values are inherited
+        self.assertEqual(config['client'], "qpu")
+
+    def _load_config_from_file(self, asked, provided):
+        self.assertEqual(asked, provided)
+        return self.parse_config_string(self.config_body)
+
+
+    def test_config_load_configfile_arg(self):
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided='myfile')):
+            self._assert_config_valid(load_config(config_file='myfile', profile='alpha'))
+
+    def test_config_load_configfile_env(self):
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided='myfile')):
+            os.environ = {'DWAVE_CONFIG_FILE': 'myfile'}
+            self._assert_config_valid(load_config(config_file=None, profile='alpha'))
+
+    def test_config_load_configfile_detect(self):
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided=None)):
+            self._assert_config_valid(load_config(config_file=None, profile='alpha'))
+
+    def test_config_load_configfile_detect_profile_env(self):
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided=None)):
+            os.environ = {'DWAVE_PROFILE': 'alpha'}
+            self._assert_config_valid(load_config())
+
+    def test_config_load_configfile_env_profile_env(self):
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided='myfile')):
+            os.environ = {'DWAVE_CONFIG_FILE': 'myfile', 'DWAVE_PROFILE': 'alpha'}
+            self._assert_config_valid(load_config())
+
+    def test_config_load_configfile_env_profile_env_key_arg(self):
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided='myfile')):
+            os.environ = {'DWAVE_CONFIG_FILE': 'myfile', 'DWAVE_PROFILE': 'alpha'}
+            self.assertEqual(load_config(endpoint='manual')['endpoint'], 'manual')
+            self.assertEqual(load_config(token='manual')['token'], 'manual')
+            self.assertEqual(load_config(client='manual')['client'], 'manual')
+            self.assertEqual(load_config(solver='manual')['solver'], 'manual')
+            self.assertEqual(load_config(proxy='manual')['proxy'], 'manual')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,9 +59,12 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config['dw2000']['client'], 'qpu')
             self.assertEqual(config['software']['client'], 'sw')
 
-    def test_no_config(self):
+    def test_no_config_detected(self):
         with mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None):
             self.assertRaises(ValueError, load_config)
+
+    def test_invalid_filename_given(self):
+        self.assertRaises(ValueError, load_config, filename='/path/to/non/existing/config')
 
     def test_config_load_profile(self):
         with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,3 +89,7 @@ class TestConfig(unittest.TestCase):
         configpath = "/etc/xdg/dwave/dwave.conf"
         with mock.patch("os.path.exists", lambda path: path == configpath):
             self.assertEqual(detect_configfile_path(), configpath)
+
+    def test_config_file_detection_nonexisting(self):
+        with mock.patch("os.path.exists", lambda path: False):
+            self.assertEqual(detect_configfile_path(), None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,7 +37,7 @@ from dwave.cloud.config import (
 
 class TestConfig(unittest.TestCase):
 
-    config_body = """
+    config_body = u"""
         [defaults]
         endpoint = https://cloud.dwavesys.com/sapi
         client = qpu

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,10 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config['dw2000']['client'], 'qpu')
             self.assertEqual(config['software']['client'], 'sw')
 
+    def test_no_config(self):
+        with mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None):
+            self.assertRaises(IOError, load_config)
+
     def test_config_load_profile(self):
         with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):
             profile = load_profile(name="alpha", filename="filename")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,7 @@ class TestConfig(unittest.TestCase):
 
     config_body = """
         [defaults]
-        url = https://cloud.dwavesys.com/sapi
+        endpoint = https://cloud.dwavesys.com/sapi
         client = qpu
 
         [dw2000]
@@ -49,7 +49,7 @@ class TestConfig(unittest.TestCase):
         token = ...
 
         [alpha]
-        url = https://url.to.alpha/api
+        endpoint = https://url.to.alpha/api
         proxy = http://user:pass@myproxy.com:8080/
         token = alpha-token
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,7 +61,7 @@ class TestConfig(unittest.TestCase):
 
     def test_no_config(self):
         with mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None):
-            self.assertRaises(IOError, load_config)
+            self.assertRaises(ValueError, load_config)
 
     def test_config_load_profile(self):
         with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, print_function
+
+import unittest
+import textwrap
+
+try:
+    # python 3
+    import unittest.mock as mock
+
+    def iterable_mock_open(data):
+        m = mock.mock_open(read_data=data)
+        m.return_value.__iter__ = lambda self: self
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        return m
+
+    configparser_open_namespace = "configparser.open"
+
+except ImportError:
+    # python 2
+    import mock
+
+    def iterable_mock_open(data):
+        m = mock.mock_open(read_data=data)
+        m.return_value.__iter__ = lambda self: iter(self.readline, '')
+        return m
+
+    configparser_open_namespace = "backports.configparser.open"
+
+
+from dwave.cloud.config import detect_configfile_path, load_config, load_profile
+
+
+class TestConfig(unittest.TestCase):
+
+    config_body = """
+        [defaults]
+        url = https://cloud.dwavesys.com/sapi
+        client = qpu
+
+        [dw2000]
+        solver = DW_2000Q_1
+        token = ...
+
+        [software]
+        client = sw
+        solver = c4-sw_sample
+        token = ...
+
+        [alpha]
+        url = https://url.to.alpha/api
+        proxy = http://user:pass@myproxy.com:8080/
+        token = alpha-token
+    """
+
+    def test_config_load(self):
+        with mock.patch(configparser_open_namespace, iterable_mock_open(self.config_body), create=True):
+            config = load_config(filename="filename")
+            self.assertEqual(config.sections(), ['dw2000', 'software', 'alpha'])
+            self.assertEqual(config['dw2000']['client'], 'qpu')
+            self.assertEqual(config['software']['client'], 'sw')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+import sys
 import unittest
 import textwrap
 
@@ -79,14 +80,26 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(detect_configfile_path(), configpath)
 
     def test_config_file_detection_user(self):
-        # assume Unix, XDG Base spec
-        configpath = os.path.expanduser("~/.config/dwave/dwave.conf")
+        if sys.platform == 'win32':
+            # TODO
+            pass
+        elif sys.platform == 'darwin':
+            configpath = os.path.expanduser("~/Library/Application Support/dwave/dwave.conf")
+        else:
+            configpath = os.path.expanduser("~/.config/dwave/dwave.conf")
+
         with mock.patch("os.path.exists", lambda path: path == configpath):
             self.assertEqual(detect_configfile_path(), configpath)
 
     def test_config_file_detection_system(self):
-        # assume Unix, XDG Base spec
-        configpath = "/etc/xdg/dwave/dwave.conf"
+        if sys.platform == 'win32':
+            # TODO
+            pass
+        elif sys.platform == 'darwin':
+            configpath = os.path.expanduser("/Library/Application Support/dwave/dwave.conf")
+        else:
+            configpath = "/etc/xdg/dwave/dwave.conf"
+
         with mock.patch("os.path.exists", lambda path: path == configpath):
             self.assertEqual(detect_configfile_path(), configpath)
 

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -249,7 +249,7 @@ class MockConfiguration(unittest.TestCase):
     def test_only_file_key(self):
         """If give a name from the config file the proper URL should be loaded."""
         with mock.patch("dwave.cloud.config.open", mock.mock_open(read_data=config_body), create=True):
-            client = Client('alpha')
+            client = Client(profile='alpha')
             client.session.get = GetEvent.handle
             try:
                 client.get_solver('arg-solver')

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -133,9 +133,9 @@ class MockSubmission(_QueryTest):
 
     def test_submit_null_reply(self):
         """Get an error when the server's response is incomplete."""
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
-            client.session.post = lambda a, _: choose_reply(a, {'problems/': ''})
+            client.session.post = lambda a, _: choose_reply(a, {'endpoint/problems/': ''})
             solver = Solver(client, solver_data('abc123'))
 
             # Build a problem
@@ -149,11 +149,11 @@ class MockSubmission(_QueryTest):
 
     def test_submit_ok_reply(self):
         """Handle a normal query and response."""
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
             client.session.post = lambda a, _: choose_reply(a, {
-                'problems/': '[%s]' % complete_no_answer_reply('123', 'abc123')})
-            client.session.get = lambda a: choose_reply(a, {'problems/123/': complete_reply('123', 'abc123')})
+                'endpoint/problems/': '[%s]' % complete_no_answer_reply('123', 'abc123')})
+            client.session.get = lambda a: choose_reply(a, {'endpoint/problems/123/': complete_reply('123', 'abc123')})
             solver = Solver(client, solver_data('abc123'))
 
             # Build a problem
@@ -167,10 +167,10 @@ class MockSubmission(_QueryTest):
     def test_submit_error_reply(self):
         """Handle an error on problem submission."""
         error_body = 'An error message'
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
             client.session.post = lambda a, _: choose_reply(a, {
-                'problems/': '[%s]' % error_reply('123', 'abc123', error_body)})
+                'endpoint/problems/': '[%s]' % error_reply('123', 'abc123', error_body)})
             solver = Solver(client, solver_data('abc123'))
 
             # Build a problem
@@ -184,9 +184,9 @@ class MockSubmission(_QueryTest):
 
     def test_submit_cancel_reply(self):
         """Handle a response for a canceled job."""
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
-            client.session.post = lambda a, _: choose_reply(a, {'problems/': '[%s]' % cancel_reply('123', 'abc123')})
+            client.session.post = lambda a, _: choose_reply(a, {'endpoint/problems/': '[%s]' % cancel_reply('123', 'abc123')})
             solver = Solver(client, solver_data('abc123'))
 
             # Build a problem
@@ -200,12 +200,12 @@ class MockSubmission(_QueryTest):
 
     def test_submit_continue_then_ok_reply(self):
         """Handle polling for a complete problem."""
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
-            client.session.post = lambda a, _: choose_reply(a, {'problems/': '[%s]' % continue_reply('123', 'abc123')})
+            client.session.post = lambda a, _: choose_reply(a, {'endpoint/problems/': '[%s]' % continue_reply('123', 'abc123')})
             client.session.get = lambda a: choose_reply(a, {
-                'problems/?id=123': '[%s]' % complete_no_answer_reply('123', 'abc123'),
-                'problems/123/': complete_reply('123', 'abc123')
+                'endpoint/problems/?id=123': '[%s]' % complete_no_answer_reply('123', 'abc123'),
+                'endpoint/problems/123/': complete_reply('123', 'abc123')
             })
             solver = Solver(client, solver_data('abc123'))
 
@@ -219,11 +219,11 @@ class MockSubmission(_QueryTest):
 
     def test_submit_continue_then_error_reply(self):
         """Handle polling for an error message."""
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
-            client.session.post = lambda a, _: choose_reply(a, {'problems/': '[%s]' % continue_reply('123', 'abc123')})
+            client.session.post = lambda a, _: choose_reply(a, {'endpoint/problems/': '[%s]' % continue_reply('123', 'abc123')})
             client.session.get = lambda a: choose_reply(a, {
-                'problems/?id=123': '[%s]' % error_reply('123', 'abc123', "error message")})
+                'endpoint/problems/?id=123': '[%s]' % error_reply('123', 'abc123', "error message")})
             solver = Solver(client, solver_data('abc123'))
 
             # Build a problem
@@ -240,30 +240,30 @@ class MockSubmission(_QueryTest):
         # Reduce the number of poll threads to 1 so that the system can be tested
         old_value = Client._POLL_THREAD_COUNT
         Client._POLL_THREAD_COUNT = 1
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
             client.session.get = lambda a: choose_reply(a, {
                 # Wait until both problems are
-                'problems/?id=1': '[%s]' % continue_reply('1', 'abc123'),
-                'problems/?id=2': '[%s]' % continue_reply('2', 'abc123'),
-                'problems/?id=2,1': '[' + complete_no_answer_reply('2', 'abc123') + ',' +
+                'endpoint/problems/?id=1': '[%s]' % continue_reply('1', 'abc123'),
+                'endpoint/problems/?id=2': '[%s]' % continue_reply('2', 'abc123'),
+                'endpoint/problems/?id=2,1': '[' + complete_no_answer_reply('2', 'abc123') + ',' +
                                      error_reply('1', 'abc123', 'error') + ']',
-                'problems/?id=1,2': '[' + error_reply('1', 'abc123', 'error') + ',' +
+                'endpoint/problems/?id=1,2': '[' + error_reply('1', 'abc123', 'error') + ',' +
                                      complete_no_answer_reply('2', 'abc123') + ']',
-                'problems/1/': error_reply('1', 'abc123', 'Error message'),
-                'problems/2/': complete_reply('2', 'abc123')
+                'endpoint/problems/1/': error_reply('1', 'abc123', 'Error message'),
+                'endpoint/problems/2/': complete_reply('2', 'abc123')
             })
 
             def switch_post_reply(path, body):
                 message = json.loads(body)
                 if len(message) == 1:
                     client.session.post = lambda a, _: choose_reply(a, {
-                        'problems/': '[%s]' % continue_reply('2', 'abc123')})
+                        'endpoint/problems/': '[%s]' % continue_reply('2', 'abc123')})
                     return choose_reply('', {'': '[%s]' % continue_reply('1', 'abc123')})
                 else:
                     client.session.post = None
-                    return choose_reply('', {
-                        '': '[%s, %s]' % (continue_reply('1', 'abc123'), continue_reply('2', 'abc123'))
+                    return choose_reply('endpoint/', {
+                        'endpoint/': '[%s, %s]' % (continue_reply('1', 'abc123'), continue_reply('2', 'abc123'))
                     })
 
             client.session.post = lambda a, body: switch_post_reply(a, body)
@@ -308,10 +308,10 @@ class MockCancel(unittest.TestCase):
         submission_id = 'test-id'
         reply_body = '[%s]' % continue_reply(submission_id, 'solver')
 
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
 
-            client.session.get = lambda a: choose_reply(a, {'problems/?id={}'.format(submission_id): reply_body})
+            client.session.get = lambda a: choose_reply(a, {'endpoint/problems/?id={}'.format(submission_id): reply_body})
             client.session.delete = DeleteEvent.handle
 
             solver = Solver(client, solver_data('abc123'))
@@ -323,10 +323,10 @@ class MockCancel(unittest.TestCase):
                 future.samples
                 self.fail()
             except DeleteEvent as event:
-                if event.url == 'problems/':
+                if event.url == 'endpoint/problems/':
                     self.assertEqual(event.body, '["{}"]'.format(submission_id))
                 else:
-                    self.assertEqual(event.url, 'problems/{}/'.format(submission_id))
+                    self.assertEqual(event.url, 'endpoint/problems/{}/'.format(submission_id))
 
     def test_cancel_without_id(self):
         """Make sure the cancel method submits to the right endpoint.
@@ -338,13 +338,13 @@ class MockCancel(unittest.TestCase):
 
         release_reply = threading.Event()
 
-        with Client('', '') as client:
+        with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
-            client.session.get = lambda a: choose_reply(a, {'problems/?id={}'.format(submission_id): reply_body})
+            client.session.get = lambda a: choose_reply(a, {'endpoint/problems/?id={}'.format(submission_id): reply_body})
 
             def post(a, _):
                 release_reply.wait()
-                return choose_reply(a, {'problems/'.format(submission_id): reply_body})
+                return choose_reply(a, {'endpoint/problems/'.format(submission_id): reply_body})
             client.session.post = post
             client.session.delete = DeleteEvent.handle
 
@@ -360,7 +360,7 @@ class MockCancel(unittest.TestCase):
                 future.samples
                 self.fail()
             except DeleteEvent as event:
-                if event.url == 'problems/':
+                if event.url == 'endpoint/problems/':
                     self.assertEqual(event.body, '["{}"]'.format(submission_id))
                 else:
-                    self.assertEqual(event.url, 'problems/{}/'.format(submission_id))
+                    self.assertEqual(event.url, 'endpoint/problems/{}/'.format(submission_id))

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -10,14 +10,14 @@ import unittest
 import random
 
 from dwave.cloud.utils import evaluate_ising
-from dwave.cloud.config import load_configuration
+from dwave.cloud.config import legacy_load_config
 from dwave.cloud.qpu import Client
 from dwave.cloud.exceptions import CanceledFutureError
 import dwave.cloud.qpu.computation
 
 
 try:
-    config_url, config_token, _, config_solver = load_configuration()
+    config_url, config_token, _, config_solver = legacy_load_config()
     if None in [config_url, config_token, config_solver]:
         raise ValueError()
     skip_live = False


### PR DESCRIPTION
The old `.dwrc` config file and `DW_INTERNAL__*` environment variables are being deprecated in favor of the new Windows INI-style based format. The new config files hold multiple profiles and can reside in multiple locations on file system. Configuration file is searched for in an OS-dependent list of potential config file locations (starting in cwd, then looking in user-local config store, and finally in a list of system-global config dirs).