### PR TITLE
Improve profile name detection

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -114,7 +114,7 @@ class Client(object):
 
         _LOGGER.debug("Creating a client for endpoint: %r", endpoint)
 
-        self.base_url = endpoint
+        self.endpoint = endpoint
         self.token = token
         self.default_solver = solver
 
@@ -249,7 +249,7 @@ class Client(object):
 
             _LOGGER.debug("Requesting list of all solver data.")
             response = self.session.get(
-                posixpath.join(self.base_url, 'solvers/remote/'))
+                posixpath.join(self.endpoint, 'solvers/remote/'))
 
             if response.status_code == 401:
                 raise SolverAuthenticationError
@@ -299,7 +299,7 @@ class Client(object):
         with self._solvers_lock:
             if refresh or name not in self._solvers:
                 response = self.session.get(
-                    posixpath.join(self.base_url, 'solvers/remote/{}/'.format(name)))
+                    posixpath.join(self.endpoint, 'solvers/remote/{}/'.format(name)))
 
                 if response.status_code == 401:
                     raise SolverAuthenticationError
@@ -353,7 +353,7 @@ class Client(object):
                 _LOGGER.debug("submitting {} problems".format(len(ready_problems)))
                 body = '[' + ','.join(mess.body for mess in ready_problems) + ']'
                 try:
-                    response = self.session.post(posixpath.join(self.base_url, 'problems/'), body)
+                    response = self.session.post(posixpath.join(self.endpoint, 'problems/'), body)
 
                     if response.status_code == 401:
                         raise SolverAuthenticationError()
@@ -482,7 +482,7 @@ class Client(object):
                 # body of the delete query.
                 try:
                     body = [item[0] for item in item_list]
-                    self.session.delete(posixpath.join(self.base_url, 'problems/'), json=body)
+                    self.session.delete(posixpath.join(self.endpoint, 'problems/'), json=body)
                 except Exception as err:
                     for _, future in item_list:
                         if future is not None:
@@ -551,7 +551,7 @@ class Client(object):
                 query_string = 'problems/?id=' + ','.join(active_queries)
 
                 try:
-                    response = self.session.get(posixpath.join(self.base_url, query_string))
+                    response = self.session.get(posixpath.join(self.endpoint, query_string))
 
                     if response.status_code == 401:
                         raise SolverAuthenticationError()
@@ -614,7 +614,7 @@ class Client(object):
                 # Submit the query
                 query_string = 'problems/{}/'.format(future.id)
                 try:
-                    response = self.session.get(posixpath.join(self.base_url, query_string))
+                    response = self.session.get(posixpath.join(self.endpoint, query_string))
 
                     if response.status_code == 401:
                         raise SolverAuthenticationError()

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -128,7 +128,7 @@ def load_config(config_file=None, profile=None, client=None,
     ``defaults``.
 
     If the location of `config_file` is not specified, an auto-detection is
-    performed (looking first for `dwave.conf` in process' current working
+    performed (looking first for ``dwave.conf`` in process' current working
     directory, then in user-local config directories, and finally in system-wide
     config dirs). For details on format and location detection, see
     :func:`load_config_from_file`.
@@ -166,7 +166,9 @@ def load_config(config_file=None, profile=None, client=None,
 
         profile (str, default=None):
             Profile name (config file section name). If undefined (by default),
-            config file values are not used at all.
+            it is inferred from ``DWAVE_PROFILE`` environment variable, and if
+            that variable is not present, ``profile`` key is looked-up in the
+            ``[defaults]`` config section.
 
         client (str, default=None):
             Client (selected by name) to use for accessing the API. Use ``qpu``
@@ -222,11 +224,13 @@ def load_config(config_file=None, profile=None, client=None,
         config_file = os.getenv("DWAVE_CONFIG_FILE")
     try:
         config = load_config_from_file(config_file)
+        default_profile = config.defaults().get('profile')
     except ValueError:
         config = {}
+        default_profile = None
 
     if profile is None:
-        profile = os.getenv("DWAVE_PROFILE")
+        profile = os.getenv("DWAVE_PROFILE", default_profile)
     if profile:
         try:
             section = dict(config[profile])

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -224,7 +224,11 @@ def load_config(config_file=None, profile=None, client=None,
         config_file = os.getenv("DWAVE_CONFIG_FILE")
     try:
         config = load_config_from_file(config_file)
-        default_profile = config.defaults().get('profile')
+        # last-resort profile name:
+        #  (1) profile key under [defaults],
+        #  (2) first non-[defaults] section
+        first_section = next(iter(config.sections() + [None]))
+        default_profile = config.defaults().get('profile', first_section)
     except ValueError:
         config = {}
         default_profile = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,11 +37,6 @@ from dwave.cloud.config import (
 
 class TestConfig(unittest.TestCase):
 
-    env = {'DWAVE_CONFIG_FILE': None, 'DWAVE_PROFILE': None,
-           'DWAVE_API_CLIENT': None, 'DWAVE_API_ENDPOINT': None,
-           'DWAVE_API_TOKEN': None, 'DWAVE_API_SOLVER': None,
-           'DWAVE_API_PROXY': None}
-
     config_body = u"""
         [defaults]
         endpoint = https://cloud.dwavesys.com/sapi
@@ -78,8 +73,9 @@ class TestConfig(unittest.TestCase):
     def setUp(self):
         # clear `config_load`-relevant environment variables before testing, so
         # we only need to patch the ones that we are currently testing
-        for key in self.env.keys():
-            os.environ.pop(key, None)
+        for key in frozenset(os.environ.keys()):
+            if key.startswith("DWAVE_") or key.startswith("DW_INTERNAL__"):
+                os.environ.pop(key, None)
 
     def test_config_load_from_file__invalid_format__duplicate_sections(self):
         """Config loading should fail with `ValueError` on file load error."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -213,6 +213,21 @@ class TestConfig(unittest.TestCase):
             profile = load_config(config_file='myfile')
             self.assertEqual(profile['solver'], 'c4-sw_sample')
 
+    def test_config_load__profile_first_section(self):
+        """load_config should fail if the profile specified as the first section
+        if not otherwise specified.
+        """
+        myconfig = u"""
+            [first]
+            solver = DW_2000Q_1
+        """
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file,
+                                provided=None, data=myconfig)):
+            profile = load_config()
+            self.assertIn('solver', profile)
+            self.assertEqual(profile['solver'], 'DW_2000Q_1')
+
     def test_config_load_configfile_arg_profile_default_nonexisting(self):
         """load_config should fail if the profile specified in the defaults
         section is non-existing.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,18 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config['dw2000']['client'], 'qpu')
             self.assertEqual(config['software']['client'], 'sw')
 
+    def test_config_load_from_file__invalid_format__duplicate_sections(self):
+        """Config loading should fail with `ValueError` on file load error."""
+        myconfig = u"""
+            [section]
+            key = val
+            [section]
+            key = val
+        """
+        with mock.patch(configparser_open_namespace, iterable_mock_open(myconfig), create=True):
+            self.assertRaises(ValueError, load_config_from_file, filename="filename")
+            self.assertRaises(ValueError, load_config, config_file="filename", profile="section")
+
     def test_no_config_detected(self):
         with mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None):
             self.assertRaises(ValueError, load_config_from_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,6 +171,7 @@ class TestConfig(unittest.TestCase):
             self._assert_config_valid(load_config())
 
     def test_config_load_configfile_env_profile_env_key_arg(self):
+        """Explicitly provided values should override env/file."""
         with mock.patch("dwave.cloud.config.load_config_from_file",
                         partial(self._load_config_from_file, provided='myfile')):
             os.environ = {'DWAVE_CONFIG_FILE': 'myfile', 'DWAVE_PROFILE': 'alpha'}
@@ -179,6 +180,16 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(load_config(client='manual')['client'], 'manual')
             self.assertEqual(load_config(solver='manual')['solver'], 'manual')
             self.assertEqual(load_config(proxy='manual')['proxy'], 'manual')
+
+    def test_config_load__profile_arg_nonexisting(self):
+        """load_config should fail if the profile specified in kwargs or env in
+        non-existing.
+        """
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file, provided=None)):
+            self.assertRaises(ValueError, load_config, profile="nonexisting")
+            with mock.patch.dict(os.environ, {'DWAVE_PROFILE': 'nonexisting'}):
+                self.assertRaises(ValueError, load_config)
 
     def test_config_load_configfile_arg_profile_default(self):
         """Check the right profile is loaded when `profile` specified only in

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,11 +210,27 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(profile['solver'], 'c4-sw_sample')
 
     def test_config_load__profile_first_section(self):
-        """load_config should fail if the profile specified as the first section
-        if not otherwise specified.
+        """load_config should load the first section for profile, if profile
+        is nowhere else specified.
         """
         myconfig = u"""
             [first]
+            solver = DW_2000Q_1
+        """
+        with mock.patch("dwave.cloud.config.load_config_from_file",
+                        partial(self._load_config_from_file,
+                                provided=None, data=myconfig)):
+            profile = load_config()
+            self.assertIn('solver', profile)
+            self.assertEqual(profile['solver'], 'DW_2000Q_1')
+
+    def test_config_load__profile_from_defaults(self):
+        """load_config should promote [defaults] section to profile, if profile
+        is nowhere else specified *and* not even a single non-[defaults] section
+        exists.
+        """
+        myconfig = u"""
+            [defaults]
             solver = DW_2000Q_1
         """
         with mock.patch("dwave.cloud.config.load_config_from_file",

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -207,14 +207,12 @@ alpha|file-alpha-url,file-alpha-token,,alpha-solver
 class MockConfiguration(unittest.TestCase):
     """Ensure that the precedence of configuration sources is followed."""
 
-    env = {'DWAVE_CONFIG_FILE': None, 'DWAVE_PROFILE': None,
-           'DWAVE_API_CLIENT': None, 'DWAVE_API_ENDPOINT': None,
-           'DWAVE_API_TOKEN': None, 'DWAVE_API_SOLVER': None,
-           'DWAVE_API_PROXY': None}
-
     def setUp(self):
-        for key in self.env.keys():
-            os.environ.pop(key, None)
+        # clear `config_load`-relevant environment variables before testing, so
+        # we only need to patch the ones that we are currently testing
+        for key in frozenset(os.environ.keys()):
+            if key.startswith("DWAVE_") or key.startswith("DW_INTERNAL__"):
+                os.environ.pop(key, None)
 
     def test_explicit_only(self):
         """Specify information only through function arguments."""

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -202,6 +202,8 @@ alpha|file-alpha-url,file-alpha-token,,alpha-solver
 """
 
 
+# patch the new config loading mechanism, to test only legacy config loading
+@mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None)
 class MockConfiguration(unittest.TestCase):
     """Ensure that the precedence of configuration sources is followed."""
 


### PR DESCRIPTION
Extend profile name detection heuristics during `load_config`
(i.e. during `Client.from_config`).

Basically, if `profile` is not explicitly defined (kwarg/env),
and `dwave.conf` exists, some profile is guaranteed to be
loaded (instead of failing).

In summary: if profile keyword is undefined when calling
`load_config`, profile name is inferred from `DWAVE_PROFILE`
environment variable, and if that variable is not present,
`profile` key is looked-up in the `[defaults]` config section.
If `profile` is not defined under `[defaults]`, the first section
is used. If no other sections are defined besides `[defaults]`,
the `[defaults]` section is promoted to profile.

Addresses #48.