### PR TITLE
Add missing requirements on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 six>=1.10
 requests>=2.18
 homebase>=1.0.0
+pyreadline>=2.1
 futures; python_version=="2.7"
 configparser; python_version=="2.7"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 
-install_requires = ['requests>=2.18', 'six>=1.10', 'homebase>=1.0', 'click>=6.7']
+install_requires = ['requests>=2.18', 'six>=1.10', 'homebase>=1.0', 'click>=6.7',
+                    'pyreadline>=2.1']
 
 extras_require = {
     'test': ['requests_mock', 'mock', 'numpy'],


### PR DESCRIPTION
readline is usually built-in module on Unix (but it doesn't have to be,
depending on system's readline support), and usually missing on Windows.

We're including `pyreadline` as a dependency to cover all bases.

Closes #80. Partially addresses #63.