### PR TITLE
Use thread pools responsibly

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -85,10 +85,10 @@ class Client(object):
             Run::
 
                 from dwave.cloud import Client
-                client = Client.from_config(profile='prod')
-                solver = client.get_solver()
-                computation = solver.sample_ising({}, {})
-                samples = computation.result()
+                with Client.from_config(profile='prod') as client:
+                    solver = client.get_solver()
+                    computation = solver.sample_ising({}, {})
+                    samples = computation.result()
 
         TODO: describe config loading, new config in broad strokes, refer to
         actual loaders' doc; include examples for config and usage.

--- a/dwave/cloud/qpu.py
+++ b/dwave/cloud/qpu.py
@@ -18,20 +18,22 @@ An example using the client:
     from dwave.cloud.qpu import Client
 
     # Connect using explicit connection information
-    client = Client('https://sapi-url', 'token-string')
+    # Also, note the use context manager, which ensures the resources (thread
+    # pools used by Client) are freed as soon as we're done with using client.
+    with Client('https://sapi-url', 'token-string') as client:
 
-    # Load a solver by name
-    solver = client.get_solver('test-solver')
+        # Load a solver by name
+        solver = client.get_solver('test-solver')
 
-    # Build a random Ising model on +1, -1. Build it to exactly fit the graph the solver provides
-    linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-    quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+        # Build a random Ising model on +1, -1. Build it to exactly fit the graph the solver provides
+        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-    # Send the problem for sampling, include a solver specific parameter 'num_reads'
-    computation = solver.sample_ising(linear, quad, num_reads=100)
+        # Send the problem for sampling, include a solver specific parameter 'num_reads'
+        computation = solver.sample_ising(linear, quad, num_reads=100)
 
-    # Print out the first sample
-    print(computation.samples[0])
+        # Print out the first sample (out of a hundred)
+        print(computation.samples[0])
 
 Rough workflow within the SAPI server:
  1. Submitted problems enter an input queue. Each user has an input queue per solver.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,21 +34,21 @@ class ConnectivityTests(unittest.TestCase):
     def test_bad_url(self):
         """Connect with a bad URL."""
         with self.assertRaises(IOError):
-            client = Client("not-a-url", config_token)
-            client.get_solvers()
+            with Client("not-a-url", config_token) as client:
+                client.get_solvers()
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_bad_token(self):
         """Connect with a bad token."""
         with self.assertRaises(SolverAuthenticationError):
-            client = Client(config_url, 'not-a-token')
-            client.get_solvers()
+            with Client(config_url, 'not-a-token') as client:
+                client.get_solvers()
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_good_connection(self):
         """Connect with a valid URL and token."""
-        client = Client(config_url, config_token)
-        self.assertTrue(len(client.get_solvers()) > 0)
+        with Client(config_url, config_token) as client:
+            self.assertTrue(len(client.get_solvers()) > 0)
 
 
 class SolverLoading(unittest.TestCase):
@@ -57,28 +57,28 @@ class SolverLoading(unittest.TestCase):
     @unittest.skipIf(skip_live, "No live server available.")
     def test_list_all_solvers(self):
         """List all the solvers."""
-        client = Client(config_url, config_token)
-        self.assertTrue(len(client.get_solvers()) > 0)
+        with Client(config_url, config_token) as client:
+            self.assertTrue(len(client.get_solvers()) > 0)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_load_all_solvers(self):
         """List and retrieve all the solvers."""
-        client = Client(config_url, config_token)
-        for name in client.get_solvers():
-            client.get_solver(name)
+        with Client(config_url, config_token) as client:
+            for name in client.get_solvers():
+                self.assertEqual(client.get_solver(name).id, name)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_load_bad_solvers(self):
         """Try to load a nonexistent solver."""
-        client = Client(config_url, config_token)
-        with self.assertRaises(KeyError):
-            client.get_solver("not-a-solver")
+        with Client(config_url, config_token) as client:
+            with self.assertRaises(KeyError):
+                client.get_solver("not-a-solver")
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_load_any_solver(self):
         """Load a single solver without calling get_solvers (which caches data)."""
-        client = Client(config_url, config_token)
-        client.get_solver(config_solver)
+        with Client(config_url, config_token) as client:
+            self.assertEqual(client.get_solver(config_solver).id, config_solver)
 
 
 class ClientFactory(unittest.TestCase):
@@ -87,11 +87,11 @@ class ClientFactory(unittest.TestCase):
     def test_default(self):
         conf = {k: k for k in 'endpoint token'.split()}
         with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
-            client = dwave.cloud.Client.from_config()
-            self.assertEqual(client.endpoint, 'endpoint')
-            self.assertEqual(client.token, 'token')
-            self.assertIsInstance(client, dwave.cloud.qpu.Client)
-            self.assertNotIsInstance(client, dwave.cloud.sw.Client)
+            with dwave.cloud.Client.from_config() as client:
+                self.assertEqual(client.endpoint, 'endpoint')
+                self.assertEqual(client.token, 'token')
+                self.assertIsInstance(client, dwave.cloud.qpu.Client)
+                self.assertNotIsInstance(client, dwave.cloud.sw.Client)
 
     def test_custom_kwargs(self):
         conf = {k: k for k in 'endpoint token'.split()}

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import, division
 import unittest
 import random
 
+import numpy
+
 from dwave.cloud.utils import evaluate_ising
 from dwave.cloud.config import legacy_load_config
 from dwave.cloud.qpu import Client
@@ -31,32 +33,32 @@ class PropertyLoading(unittest.TestCase):
     @unittest.skipIf(skip_live, "No live server available.")
     def test_load_properties(self):
         """Ensure that the propreties are populated."""
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-        self.assertTrue(len(solver.properties) > 0)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+            self.assertTrue(len(solver.properties) > 0)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_load_parameters(self):
         """Make sure the parameters are populated."""
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-        self.assertTrue(len(solver.parameters) > 0)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+            self.assertTrue(len(solver.parameters) > 0)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_submit_invalid_parameter(self):
         """Ensure that the parameters are populated."""
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-        assert 'not_a_parameter' not in solver.parameters
-        with self.assertRaises(KeyError):
-            solver.sample_ising({}, {}, not_a_parameter=True)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+            assert 'not_a_parameter' not in solver.parameters
+            with self.assertRaises(KeyError):
+                solver.sample_ising({}, {}, not_a_parameter=True)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_read_connectivity(self):
         """Ensure that the edge set is populated."""
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-        self.assertTrue(len(solver.edges) > 0)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+            self.assertTrue(len(solver.edges) > 0)
 
 
 class _QueryTest(unittest.TestCase):
@@ -78,116 +80,57 @@ class Submission(_QueryTest):
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_result_structure(self):
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-        computation = solver.sample_ising({}, {})
-        result = computation.result()
-        self.assertIn('samples', result)
-        self.assertIn('energies', result)
-        self.assertIn('occurrences', result)
-        self.assertIn('timing', result)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+            computation = solver.sample_ising({}, {})
+            result = computation.result()
+            self.assertIn('samples', result)
+            self.assertIn('energies', result)
+            self.assertIn('occurrences', result)
+            self.assertIn('timing', result)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_submit_extra_qubit(self):
         """Submit a defective problem with an unsupported variable."""
         # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
 
-        # Build a linear problem
-        linear = [0] * (max(solver.nodes) + 1)
-        for index in solver.nodes:
-            linear[index] = 1
-        quad = {}
+            # Build a linear problem
+            linear = [0] * (max(solver.nodes) + 1)
+            for index in solver.nodes:
+                linear[index] = 1
+            quad = {}
 
-        # Add a variable that shouldn't exist
-        linear.append(1)
+            # Add a variable that shouldn't exist
+            linear.append(1)
 
-        with self.assertRaises(ValueError):
-            results = solver.sample_ising(linear, quad)
-            results.samples
+            with self.assertRaises(ValueError):
+                results = solver.sample_ising(linear, quad)
+                results.samples
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_submit_linear_problem(self):
         """Submit a problem with all the linear terms populated."""
         # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
 
-        # Build a linear problem
-        linear = [0] * (max(solver.nodes) + 1)
-        for index in solver.nodes:
-            linear[index] = 1
-        quad = {}
+            # Build a linear problem
+            linear = [0] * (max(solver.nodes) + 1)
+            for index in solver.nodes:
+                linear[index] = 1
+            quad = {}
 
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_submit_full_problem(self):
         """Submit a problem with all supported coefficients set."""
         # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-
-        # Build a linear problem
-        linear = [0] * (max(solver.nodes) + 1)
-        for index in solver.nodes:
-            linear[index] = random.choice([-1, 1])
-
-        # Build a
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
-
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
-
-    @unittest.skipIf(skip_live, "No live server available.")
-    def test_submit_dict_problem(self):
-        """Submit a problem using a dict for the linear terms."""
-        # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
-
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
-
-    @unittest.skipIf(skip_live, "No live server available.")
-    def test_submit_partial_problem(self):
-        """Submit a problem with only some of the terms set."""
-        # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-
-        # Build a linear problem
-        linear = [0] * (max(solver.nodes) + 1)
-        for index in solver.nodes:
-            linear[index] = random.choice([-1, 1])
-
-        # Build a
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
-
-        # Remove half the qubits
-        nodes = list(solver.nodes)
-        for index in nodes[0:len(nodes)//2]:
-            linear[index] = 0
-            quad = {key: value for key, value in quad.items() if index not in key}
-
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
-
-    @unittest.skipIf(skip_live, "No live server available.")
-    def test_submit_batch(self):
-        """Submit batch of problems."""
-        # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
-
-        result_list = []
-        for _ in range(100):
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -197,16 +140,75 @@ class Submission(_QueryTest):
             # Build a
             quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-            results = solver.sample_ising(linear, quad, num_reads=10)
-            result_list.append([results, linear, quad])
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
 
-        for results, linear, quad in result_list:
-            # Did we get the right number of samples?
-            self.assertTrue(10 == sum(results.occurrences))
+    @unittest.skipIf(skip_live, "No live server available.")
+    def test_submit_dict_problem(self):
+        """Submit a problem using a dict for the linear terms."""
+        # Connect
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
 
-            # Make sure the number of occurrences and energies are all correct
-            for energy, state in zip(results.energies, results.samples):
-                self.assertTrue(energy == evaluate_ising(linear, quad, state))
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
+
+    @unittest.skipIf(skip_live, "No live server available.")
+    def test_submit_partial_problem(self):
+        """Submit a problem with only some of the terms set."""
+        # Connect
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+
+            # Build a linear problem
+            linear = [0] * (max(solver.nodes) + 1)
+            for index in solver.nodes:
+                linear[index] = random.choice([-1, 1])
+
+            # Build a
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+
+            # Remove half the qubits
+            nodes = list(solver.nodes)
+            for index in nodes[0:len(nodes)//2]:
+                linear[index] = 0
+                quad = {key: value for key, value in quad.items() if index not in key}
+
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
+
+    @unittest.skipIf(skip_live, "No live server available.")
+    def test_submit_batch(self):
+        """Submit batch of problems."""
+        # Connect
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
+
+            result_list = []
+            for _ in range(100):
+
+                # Build a linear problem
+                linear = [0] * (max(solver.nodes) + 1)
+                for index in solver.nodes:
+                    linear[index] = random.choice([-1, 1])
+
+                # Build a
+                quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+
+                results = solver.sample_ising(linear, quad, num_reads=10)
+                result_list.append([results, linear, quad])
+
+            for results, linear, quad in result_list:
+                # Did we get the right number of samples?
+                self.assertTrue(10 == sum(results.occurrences))
+
+                # Make sure the number of occurrences and energies are all correct
+                for energy, state in zip(results.energies, results.samples):
+                    self.assertTrue(energy == evaluate_ising(linear, quad, state))
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_cancel_batch(self):
@@ -246,34 +248,34 @@ class Submission(_QueryTest):
     def test_wait_many(self):
         """Submit a batch of problems then use `wait_multiple` to wait on all of them."""
         # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
 
-        # Build a linear problem
-        linear = [0] * (max(solver.nodes) + 1)
-        for index in solver.nodes:
-            linear[index] = random.choice([-1, 1])
+            # Build a linear problem
+            linear = [0] * (max(solver.nodes) + 1)
+            for index in solver.nodes:
+                linear[index] = random.choice([-1, 1])
 
-        # Build a
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        result_list = []
-        for _ in range(100):
-            results = solver.sample_ising(linear, quad, num_reads=40)
-            result_list.append([results, linear, quad])
+            result_list = []
+            for _ in range(100):
+                results = solver.sample_ising(linear, quad, num_reads=40)
+                result_list.append([results, linear, quad])
 
-        dwave.cloud.computation.Future.wait_multiple([f[0] for f in result_list])
+            dwave.cloud.computation.Future.wait_multiple([f[0] for f in result_list])
 
-        for results, _, _ in result_list:
-            self.assertTrue(results.done())
+            for results, _, _ in result_list:
+                self.assertTrue(results.done())
 
-        for results, linear, quad in result_list:
-            # Did we get the right number of samples?
-            self.assertTrue(40 == sum(results.occurrences))
+            for results, linear, quad in result_list:
+                # Did we get the right number of samples?
+                self.assertTrue(40 == sum(results.occurrences))
 
-            # Make sure the number of occurrences and energies are all correct
-            for energy, state in zip(results.energies, results.samples):
-                self.assertTrue(energy == evaluate_ising(linear, quad, state))
+                # Make sure the number of occurrences and energies are all correct
+                for energy, state in zip(results.energies, results.samples):
+                    self.assertTrue(energy == evaluate_ising(linear, quad, state))
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_as_completed(self):
@@ -281,24 +283,24 @@ class Submission(_QueryTest):
         all of them."""
 
         # Connect
-        client = Client(config_url, config_token)
-        solver = client.get_solver(config_solver)
+        with Client(config_url, config_token) as client:
+            solver = client.get_solver(config_solver)
 
-        # Build a problem
-        linear = [0] * (max(solver.nodes) + 1)
-        for index in solver.nodes:
-            linear[index] = random.choice([-1, 1])
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = [0] * (max(solver.nodes) + 1)
+            for index in solver.nodes:
+                linear[index] = random.choice([-1, 1])
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Sample the solution 100x40 times
-        computations = [solver.sample_ising(linear, quad, num_reads=40) for _ in range(100)]
+            # Sample the solution 100x40 times
+            computations = [solver.sample_ising(linear, quad, num_reads=40) for _ in range(100)]
 
-        # Go over computations, one by one, as they're done and check they're OK
-        for computation in dwave.cloud.computation.Future.as_completed(computations):
-            self.assertTrue(computation.done())
-            self.assertTrue(40 == sum(computation.occurrences))
-            for energy, state in zip(computation.energies, computation.samples):
-                self.assertTrue(energy == evaluate_ising(linear, quad, state))
+            # Go over computations, one by one, as they're done and check they're OK
+            for computation in dwave.cloud.computation.Future.as_completed(computations):
+                self.assertTrue(computation.done())
+                self.assertTrue(40 == sum(computation.occurrences))
+                for energy, state in zip(computation.energies, computation.samples):
+                    self.assertTrue(energy == evaluate_ising(linear, quad, state))
 
 
 class DecodingMethod(_QueryTest):
@@ -323,139 +325,137 @@ class DecodingMethod(_QueryTest):
     def test_request_matrix_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        client = Client(config_url, config_token)
-        dwave.cloud.computation._numpy = False
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = True
+        with Client(config_url, config_token) as client:
+            dwave.cloud.computation._numpy = False
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = True
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        with self.assertRaises(ValueError):
-            self._submit_and_check(solver, linear, quad)
+            # Solve the problem
+            with self.assertRaises(ValueError):
+                self._submit_and_check(solver, linear, quad)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_matrix_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        import numpy
-        client = Client(config_url, config_token)
-        assert dwave.cloud.computation._numpy
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = True
+        with Client(config_url, config_token) as client:
+            assert dwave.cloud.computation._numpy
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = True
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        result = self._submit_and_check(solver, linear, quad)
-        self.assertIsInstance(result.samples, numpy.ndarray)
-        self.assertIsInstance(result.energies, numpy.ndarray)
-        self.assertIsInstance(result.occurrences, numpy.ndarray)
+            # Solve the problem
+            result = self._submit_and_check(solver, linear, quad)
+            self.assertIsInstance(result.samples, numpy.ndarray)
+            self.assertIsInstance(result.energies, numpy.ndarray)
+            self.assertIsInstance(result.occurrences, numpy.ndarray)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_list_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        client = Client(config_url, config_token)
-        dwave.cloud.computation._numpy = False
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = False
+        with Client(config_url, config_token) as client:
+            dwave.cloud.computation._numpy = False
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = False
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_list_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        client = Client(config_url, config_token)
-        assert dwave.cloud.computation._numpy
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = False
+        with Client(config_url, config_token) as client:
+            assert dwave.cloud.computation._numpy
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = False
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_raw_matrix_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        client = Client(config_url, config_token)
-        dwave.cloud.computation._numpy = False
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = True
+        with Client(config_url, config_token) as client:
+            dwave.cloud.computation._numpy = False
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = True
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        with self.assertRaises(ValueError):
-            self._submit_and_check(solver, linear, quad, answer_mode='raw')
+            # Solve the problem
+            with self.assertRaises(ValueError):
+                self._submit_and_check(solver, linear, quad, answer_mode='raw')
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_raw_matrix_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        import numpy
-        client = Client(config_url, config_token)
-        assert dwave.cloud.computation._numpy
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = True
+        with Client(config_url, config_token) as client:
+            assert dwave.cloud.computation._numpy
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = True
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        result = self._submit_and_check(solver, linear, quad, answer_mode='raw')
-        self.assertIsInstance(result.samples, numpy.ndarray)
-        self.assertIsInstance(result.energies, numpy.ndarray)
-        self.assertIsInstance(result.occurrences, numpy.ndarray)
+            # Solve the problem
+            result = self._submit_and_check(solver, linear, quad, answer_mode='raw')
+            self.assertIsInstance(result.samples, numpy.ndarray)
+            self.assertIsInstance(result.energies, numpy.ndarray)
+            self.assertIsInstance(result.occurrences, numpy.ndarray)
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_raw_list_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        client = Client(config_url, config_token)
-        dwave.cloud.computation._numpy = False
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = False
+        with Client(config_url, config_token) as client:
+            dwave.cloud.computation._numpy = False
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = False
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad, answer_mode='raw')
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad, answer_mode='raw')
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_request_raw_list_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        client = Client(config_url, config_token)
-        assert dwave.cloud.computation._numpy
-        solver = client.get_solver(config_solver)
-        solver.return_matrix = False
+        with Client(config_url, config_token) as client:
+            assert dwave.cloud.computation._numpy
+            solver = client.get_solver(config_solver)
+            solver.return_matrix = False
 
-        # Build a problem
-        linear = {index: random.choice([-1, 1]) for index in solver.nodes}
-        quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
+            # Build a problem
+            linear = {index: random.choice([-1, 1]) for index in solver.nodes}
+            quad = {key: random.choice([-1, 1]) for key in solver.undirected_edges}
 
-        # Solve the problem
-        self._submit_and_check(solver, linear, quad)
+            # Solve the problem
+            self._submit_and_check(solver, linear, quad)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prefer the use of context manager for Client, to ensure resources allocated by Client are returned to system as soon as we explicitly don't need the client.

Updated tests and docs.

Closes #91.