### PR TITLE
Progressive config files load (per-key override)

### DIFF
--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -8,8 +8,8 @@ from dwave.cloud.utils import readline_input
 from dwave.cloud.exceptions import (
     SolverAuthenticationError, InvalidAPIResponseError, UnsupportedSolverError)
 from dwave.cloud.config import (
-    load_config_from_file, get_default_config,
-    detect_configfile_path, get_default_configfile_path)
+    load_config_from_files, get_default_config,
+    get_configfile_path, get_default_configfile_path)
 
 
 @click.group()
@@ -30,7 +30,7 @@ def configure(config_file, profile):
         print("Using config file:", config_file)
     else:
         # path not given, try to detect; or use default, but allow user to override
-        config_file = detect_configfile_path()
+        config_file = get_configfile_path()
         if config_file:
             print("Found existing config file:", config_file)
         else:
@@ -40,8 +40,8 @@ def configure(config_file, profile):
 
     # try loading existing config, or use defaults
     try:
-        config = load_config_from_file(config_file)
-    except ValueError:
+        config = load_config_from_files([config_file])
+    except:
         config = get_default_config()
 
     # determine profile

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -204,7 +204,7 @@ alpha|file-alpha-url,file-alpha-token,,alpha-solver
 
 
 # patch the new config loading mechanism, to test only legacy config loading
-@mock.patch("dwave.cloud.config.detect_configfile_path", lambda: None)
+@mock.patch("dwave.cloud.config.detect_existing_configfile_paths", lambda: [])
 class MockConfiguration(unittest.TestCase):
     """Ensure that the precedence of configuration sources is followed."""
 


### PR DESCRIPTION
When multiple config files are detected (in auto-detect scenario), load them all in order of most general, to most specific, overriding with more specific values (per-section-key).

This makes the configuration process more general, and interface cleaner (config load when no files are auto-detected won't result with error, but with empty config). Failing to load and existing and auto-detected config file raises exceptions. Similarly for failing to load an explicitly named config file.

Closes #94.