### PR TITLE
 Use config file for live tests

### DIFF
--- a/dwave/cloud/exceptions.py
+++ b/dwave/cloud/exceptions.py
@@ -1,24 +1,27 @@
-class ConfigFileReadError(Exception):
+class ConfigFileError(Exception):
+    """Base exception for all config file processing errors."""
+
+class ConfigFileReadError(ConfigFileError):
     """Non-existing or unreadable config file specified or implied."""
 
-
-class ConfigFileParseError(Exception):
+class ConfigFileParseError(ConfigFileError):
     """Invalid format of config file."""
 
 
 class SolverError(Exception):
     """Generic base class for all solver-related errors."""
 
-
 class SolverFailureError(SolverError):
     """An exception raised when there is a remote failure calling a solver."""
-
 
 class SolverAuthenticationError(SolverError):
     """An exception raised when there is an authentication error."""
 
     def __init__(self):
         super(SolverAuthenticationError, self).__init__("Token not accepted for that action.")
+
+class UnsupportedSolverError(SolverError):
+    """The solver we received from the API is not supported by the client."""
 
 
 class CanceledFutureError(Exception):
@@ -30,7 +33,3 @@ class CanceledFutureError(Exception):
 
 class InvalidAPIResponseError(Exception):
     """Raised when an invalid/unexpected response from D-Wave Solver API is received."""
-
-
-class UnsupportedSolverError(SolverError):
-    """The solver we received from the API is not supported by the client."""

--- a/dwave/cloud/testing.py
+++ b/dwave/cloud/testing.py
@@ -11,12 +11,40 @@ except ImportError:
 
 @contextlib.contextmanager
 def isolated_environ(add=None, remove=None, remove_dwave=False, empty=False):
+    """Context manager for modified process environment isolation.
+
+    Environment variables can be updated, added and removed. Complete
+    environment can be cleared, or cleared only only of a subset of variables
+    that affect config loading (``DWAVE_*`` and ``DW_INTERNAL__*`` vars).
+
+    On context clear, original `os.environ` is restored.
+
+    Args:
+        add (dict/Mapping):
+            Values to add (or update) to the isolated `os.environ`.
+
+        remove (dict/Mapping, or set/Iterable):
+            Values to remove from the isolated `os.environ`.
+
+        remove_dwave (bool, default=False):
+            Remove dwave-cloud-client specific variables that affect config
+            loading (prefixed with ``DWAVE_`` or ``DW_INTERNAL__``)
+
+        empty (bool, default=False):
+            Return empty environment.
+
+    Context:
+        Modified copy of global `os.environ`. Restored on context exit.
+    """
+
     if add is None:
         add = {}
+
     with mock.patch.dict(os.environ, values=add, clear=empty):
         for key in frozenset(os.environ.keys()):
             if remove and key in remove:
                 os.environ.pop(key, None)
             if remove_dwave and (key.startswith("DWAVE_") or key.startswith("DW_INTERNAL__")):
                 os.environ.pop(key, None)
+
         yield os.environ

--- a/dwave/cloud/testing.py
+++ b/dwave/cloud/testing.py
@@ -1,0 +1,22 @@
+"""Testing utils."""
+
+import os
+import contextlib
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+@contextlib.contextmanager
+def isolated_environ(add=None, remove=None, remove_dwave=False, empty=False):
+    if add is None:
+        add = {}
+    with mock.patch.dict(os.environ, values=add, clear=empty):
+        for key in frozenset(os.environ.keys()):
+            if remove and key in remove:
+                os.environ.pop(key, None)
+            if remove_dwave and (key.startswith("DWAVE_") or key.startswith("DW_INTERNAL__")):
+                os.environ.pop(key, None)
+        yield os.environ

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,9 @@
 import os
 import warnings
+
 from dwave.cloud.config import load_config
 from dwave.cloud.exceptions import CanceledFutureError, ConfigFileError
+
 
 # try to load client config needed for live tests on SAPI webservice
 try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,23 @@
+import os
+import warnings
+from dwave.cloud.config import load_config
+from dwave.cloud.exceptions import CanceledFutureError, ConfigFileError
+
+# try to load client config needed for live tests on SAPI webservice
+try:
+    # explicitly use tests/dwave.conf, with secrets (token) read from env
+    test_config_path = os.path.join(os.path.dirname(__file__), 'dwave.conf')
+
+    # use `sw` resource instead of QPU
+    config = load_config(config_file=test_config_path, profile='sw')
+
+    # ensure config is complete
+    for var in 'endpoint token solver'.split():
+        if not config[var]:
+            raise ValueError("Config incomplete, missing: {!r}".format(var))
+
+    skip_live = False
+
+except (ConfigFileError, ValueError) as e:
+    warnings.warn("Skipping live tests due to: {!s}".format(e))
+    skip_live = True

--- a/tests/dwave.conf
+++ b/tests/dwave.conf
@@ -1,0 +1,10 @@
+[defaults]
+endpoint = https://cloud.dwavesys.com/sapi
+
+[qpu]
+solver = DW_2000Q_1
+client = qpu
+
+[sw]
+solver = c4-sw_sample
+client = sw

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,13 +4,9 @@ import os
 
 from click.testing import CliRunner
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
-
 from dwave.cloud.cli import cli
 from dwave.cloud.config import load_config
+from dwave.cloud.testing import mock, isolated_environ
 
 
 def touch(path):
@@ -28,7 +24,7 @@ class TestCli(unittest.TestCase):
 
         with mock.patch("six.moves.input", side_effect=values, create=True):
             runner = CliRunner()
-            with runner.isolated_filesystem():
+            with runner.isolated_filesystem(), isolated_environ(remove_dwave=True):
                 touch(config_file)
                 result = runner.invoke(cli, [
                     'configure', '--config-file', config_file, '--profile', profile

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,14 +17,7 @@ from dwave.cloud.qpu import Client
 from dwave.cloud.exceptions import SolverAuthenticationError
 import dwave.cloud
 
-
-try:
-    config = load_config()
-    if not config['endpoint'] or not config['token'] or not config['solver']:
-        raise ValueError
-    skip_live = False
-except:
-    skip_live = True
+from tests import config, skip_live
 
 
 class ConnectivityTests(unittest.TestCase):

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -12,19 +12,11 @@ import random
 import numpy
 
 from dwave.cloud.utils import evaluate_ising
-from dwave.cloud.config import load_config
 from dwave.cloud.qpu import Client
 from dwave.cloud.exceptions import CanceledFutureError
 import dwave.cloud.computation
 
-
-try:
-    config = load_config()
-    if not config['endpoint'] or not config['token'] or not config['solver']:
-        raise ValueError
-    skip_live = False
-except:
-    skip_live = True
+from tests import config, skip_live
 
 
 class PropertyLoading(unittest.TestCase):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,105 @@
+import os
+import uuid
+import unittest
+
+from dwave.cloud.testing import mock, isolated_environ
+
+
+@mock.patch.dict(os.environ)
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.var = str(uuid.uuid4())
+        self.val = str(uuid.uuid4())
+        self.alt = str(uuid.uuid4())
+
+    def clear(self):
+        if self.var in os.environ:
+            del os.environ[self.var]
+
+    def setval(self):
+        os.environ[self.var] = self.val
+
+    def test_isolation(self):
+        # set var to val in "global" env
+        self.setval()
+        self.assertEqual(os.getenv(self.var), self.val)
+
+        # ensure isolated env stores modified value
+        with isolated_environ():
+            os.environ[self.var] = self.alt
+            self.assertEqual(os.getenv(self.var), self.alt)
+
+        # ensure "global" env is restored
+        self.assertEqual(os.getenv(self.var), self.val)
+
+    def test_update(self):
+        # set var to val in "global" env
+        self.setval()
+        self.assertEqual(os.getenv(self.var), self.val)
+
+        # ensure isolated env has modified value
+        with isolated_environ({self.var: self.alt}):
+            self.assertEqual(os.getenv(self.var), self.alt)
+
+        # ensure "global" env is restored
+        self.assertEqual(os.getenv(self.var), self.val)
+
+    def test_add(self):
+        # clear var in "global" env
+        self.clear()
+        self.assertEqual(os.getenv(self.var), None)
+
+        # ensure isolated env adds var
+        with isolated_environ({self.var: self.val}):
+            self.assertEqual(os.getenv(self.var), self.val)
+
+        # ensure "global" env is restored
+        self.assertEqual(os.getenv(self.var), None)
+
+    def test_remove(self):
+        # set var to val in "global" env
+        self.setval()
+        self.assertEqual(os.getenv(self.var), self.val)
+
+        # ensure isolated env removes var
+        with isolated_environ(remove={self.var: self.val}):
+            self.assertEqual(os.getenv(self.var), None)
+        with isolated_environ(remove=[self.var]):
+            self.assertEqual(os.getenv(self.var), None)
+        with isolated_environ(remove=set([self.var])):
+            self.assertEqual(os.getenv(self.var), None)
+
+        # ensure "global" env is restored
+        self.assertEqual(os.getenv(self.var), self.val)
+
+    def test_remove_dwave(self):
+        # set var to val in "global" env
+        dw1, dw2 = 'DWAVE_TEST', 'DW_INTERNAL__TEST'
+        val = 'test'
+        os.environ[dw1] = val
+        os.environ[dw2] = val
+
+        # ensure isolated env removes dwave var
+        with isolated_environ(remove_dwave=True):
+            self.assertEqual(os.getenv(dw1), None)
+            self.assertEqual(os.getenv(dw2), None)
+
+        # ensure "global" env is restored
+        self.assertEqual(os.getenv(dw1), val)
+        self.assertEqual(os.getenv(dw2), val)
+
+    def test_empty(self):
+        # set var to val in "global" env
+        self.setval()
+        self.assertEqual(os.getenv(self.var), self.val)
+
+        # ensure isolated env starts empty
+        with isolated_environ(empty=True):
+            self.assertEqual(os.getenv(self.var), None)
+
+        # ensure "global" env is restored
+        self.assertEqual(os.getenv(self.var), self.val)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Client test conf centralized and explicit (in `tests/dwave.conf`),
independent of user/main conf.

Introduce `dwave.cloud.testing` module with testing utils like `isolated_environ`, `iterable_mock_open` and cross-python compatible convenience `mock` import.

Closes #64.