### PR TITLE
Cleaner use of config in (live) tests

### DIFF
--- a/dwave/cloud/__init__.py
+++ b/dwave/cloud/__init__.py
@@ -1,5 +1,17 @@
 from __future__ import absolute_import
 
+import logging
+
 from dwave.cloud.client import Client
 from dwave.cloud.solver import Solver
 from dwave.cloud.computation import Future
+
+
+# configure logger `dwave.cloud` root logger, inherited in submodules
+# (write level warning+ to stderr, include timestamp/module/level)
+formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+root = logging.getLogger(__name__)
+root.setLevel(logging.WARNING)
+root.addHandler(handler)

--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -1,23 +1,23 @@
 from __future__ import division, absolute_import
 
-import threading
-import time
 import sys
-import posixpath
+import time
 import logging
+import threading
 import requests
+import posixpath
 import collections
-from dateutil.parser import parse as parse_timestamp
 from itertools import chain
+
+from dateutil.parser import parse as parse_timestamp
 from six.moves import queue, range
 
 from dwave.cloud.exceptions import *
 from dwave.cloud.config import load_config, legacy_load_config
 from dwave.cloud.solver import Solver
 
+
 _LOGGER = logging.getLogger(__name__)
-# _LOGGER.setLevel(logging.DEBUG)
-# _LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 
 class Client(object):

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -346,6 +346,7 @@ def load_config(config_file=None, profile=None, client=None,
     else:
         # auto-detect if not specified with arg or env
         if config_file is None:
+            # note: both empty and undefined DWAVE_CONFIG_FILE treated as None
             config_file = os.getenv("DWAVE_CONFIG_FILE")
         section = _get_section([config_file] if config_file else None, profile)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,13 +5,16 @@ from dwave.cloud.config import load_config
 from dwave.cloud.exceptions import CanceledFutureError, ConfigFileError
 
 
-# try to load client config needed for live tests on SAPI webservice
+# try to load client config needed for live tests on SAPI web service
 try:
-    # explicitly use tests/dwave.conf, with secrets (token) read from env
-    test_config_path = os.path.join(os.path.dirname(__file__), 'dwave.conf')
+    # by default, use `test` profile from `tests/dwave.conf`,
+    # with secrets (token) read from env
+    default_config_path = os.path.join(os.path.dirname(__file__), 'dwave.conf')
+    default_config_profile = 'test'
 
-    # use `sw` resource instead of QPU
-    test_config_profile = 'sw'
+    # allow manual override of config file and profile used for tests
+    test_config_path = os.getenv('DWAVE_CONFIG_FILE', default_config_path)
+    test_config_profile = os.getenv('DWAVE_PROFILE', default_config_profile)
 
     config = load_config(config_file=test_config_path,
                          profile=test_config_profile)

--- a/tests/dwave.conf
+++ b/tests/dwave.conf
@@ -5,6 +5,6 @@ endpoint = https://cloud.dwavesys.com/sapi
 solver = DW_2000Q_1
 client = qpu
 
-[sw]
+[test]
 solver = c4-sw_sample
 client = sw

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,18 +23,22 @@ class ConnectivityTests(unittest.TestCase):
     def test_bad_url(self):
         """Connect with a bad URL."""
         with self.assertRaises(IOError):
-            with Client("not-a-url", config['token']) as client:
+            invalid_config = config.copy()
+            invalid_config.update(endpoint='invalid-endpoint')
+            with Client(**invalid_config) as client:
                 client.get_solvers()
 
     def test_bad_token(self):
         """Connect with a bad token."""
         with self.assertRaises(SolverAuthenticationError):
-            with Client(config['endpoint'], 'not-a-token') as client:
+            invalid_config = config.copy()
+            invalid_config.update(token='invalid-token')
+            with Client(**invalid_config) as client:
                 client.get_solvers()
 
     def test_good_connection(self):
-        """Connect with a valid URL and token."""
-        with Client(config['endpoint'], config['token']) as client:
+        """Connect with valid connection settings (url/token/proxy/etc)."""
+        with Client(**config) as client:
             self.assertTrue(len(client.get_solvers()) > 0)
 
 
@@ -44,24 +48,24 @@ class SolverLoading(unittest.TestCase):
 
     def test_list_all_solvers(self):
         """List all the solvers."""
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             self.assertTrue(len(client.get_solvers()) > 0)
 
     def test_load_all_solvers(self):
         """List and retrieve all the solvers."""
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             for name in client.get_solvers():
                 self.assertEqual(client.get_solver(name).id, name)
 
     def test_load_bad_solvers(self):
         """Try to load a nonexistent solver."""
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             with self.assertRaises(KeyError):
                 client.get_solver("not-a-solver")
 
     def test_load_any_solver(self):
         """Load a single solver without calling get_solvers (which caches data)."""
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             self.assertEqual(client.get_solver(config['solver']).id, config['solver'])
 
 

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -211,7 +211,7 @@ solver = alpha-solver
 
 # patch the new config loading mechanism, to test only legacy config loading
 @mock.patch("dwave.cloud.config.detect_existing_configfile_paths", lambda: [])
-class MockConfiguration(unittest.TestCase):
+class MockLegacyConfiguration(unittest.TestCase):
     """Ensure that the precedence of configuration sources is followed."""
 
     def setUp(self):

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -138,7 +138,6 @@ class MockSubmission(_QueryTest):
             quad = {key: -1 for key in solver.undirected_edges}
             results = solver.sample_ising(linear, quad, num_reads=100)
 
-            #
             with self.assertRaises(ValueError):
                 results.samples
 
@@ -156,7 +155,6 @@ class MockSubmission(_QueryTest):
             quad = {key: -1 for key in solver.undirected_edges}
             results = solver.sample_ising(linear, quad, num_reads=100)
 
-            #
             self._check(results, linear, quad, 100)
 
     def test_submit_error_reply(self):
@@ -173,7 +171,6 @@ class MockSubmission(_QueryTest):
             quad = {key: -1 for key in solver.undirected_edges}
             results = solver.sample_ising(linear, quad, num_reads=100)
 
-            #
             with self.assertRaises(SolverFailureError):
                 results.samples
 
@@ -189,7 +186,6 @@ class MockSubmission(_QueryTest):
             quad = {key: -1 for key in solver.undirected_edges}
             results = solver.sample_ising(linear, quad, num_reads=100)
 
-            #
             with self.assertRaises(CanceledFutureError):
                 results.samples
 
@@ -209,7 +205,6 @@ class MockSubmission(_QueryTest):
             quad = {key: -1 for key in solver.undirected_edges}
             results = solver.sample_ising(linear, quad, num_reads=100)
 
-            #
             self._check(results, linear, quad, 100)
 
     def test_submit_continue_then_error_reply(self):
@@ -226,7 +221,6 @@ class MockSubmission(_QueryTest):
             quad = {key: -1 for key in solver.undirected_edges}
             results = solver.sample_ising(linear, quad, num_reads=100)
 
-            #
             with self.assertRaises(SolverFailureError):
                 self._check(results, linear, quad, 100)
 
@@ -235,6 +229,7 @@ class MockSubmission(_QueryTest):
         # Reduce the number of poll threads to 1 so that the system can be tested
         old_value = Client._POLL_THREAD_COUNT
         Client._POLL_THREAD_COUNT = 1
+
         with Client('endpoint', 'token') as client:
             client.session = mock.Mock()
             client.session.get = lambda a: choose_reply(a, {
@@ -274,6 +269,7 @@ class MockSubmission(_QueryTest):
             with self.assertRaises(SolverFailureError):
                 self._check(results1, linear, quad, 100)
             self._check(results2, linear, quad, 100)
+
         Client._POLL_THREAD_COUNT = old_value
 
 
@@ -338,7 +334,7 @@ class MockCancel(unittest.TestCase):
 
             def post(a, _):
                 release_reply.wait()
-                return choose_reply(a, {'endpoint/problems/'.format(submission_id): reply_body})
+                return choose_reply(a, {'endpoint/problems/': reply_body})
             client.session.post = post
             client.session.delete = DeleteEvent.handle
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -26,28 +26,28 @@ class PropertyLoading(unittest.TestCase):
 
     def test_load_properties(self):
         """Ensure that the propreties are populated."""
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
             self.assertTrue(len(solver.properties) > 0)
 
     def test_load_parameters(self):
         """Make sure the parameters are populated."""
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
             self.assertTrue(len(solver.parameters) > 0)
 
     def test_submit_invalid_parameter(self):
         """Ensure that the parameters are populated."""
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
             assert 'not_a_parameter' not in solver.parameters
             with self.assertRaises(KeyError):
                 solver.sample_ising({}, {}, not_a_parameter=True)
 
     def test_read_connectivity(self):
         """Ensure that the edge set is populated."""
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
             self.assertTrue(len(solver.edges) > 0)
 
 
@@ -70,8 +70,8 @@ class Submission(_QueryTest):
     """Submit some sample problems."""
 
     def test_result_structure(self):
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
             computation = solver.sample_ising({}, {})
             result = computation.result()
             self.assertIn('samples', result)
@@ -80,8 +80,8 @@ class Submission(_QueryTest):
             self.assertIn('timing', result)
 
     def test_future_structure(self):
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
             computation = solver.sample_ising({}, {})
             _ = computation.result()
             self.assertIsInstance(computation.id, str)
@@ -93,8 +93,8 @@ class Submission(_QueryTest):
     def test_submit_extra_qubit(self):
         """Submit a defective problem with an unsupported variable."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -112,8 +112,8 @@ class Submission(_QueryTest):
     def test_submit_linear_problem(self):
         """Submit a problem with all the linear terms populated."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -127,8 +127,8 @@ class Submission(_QueryTest):
     def test_submit_full_problem(self):
         """Submit a problem with all supported coefficients set."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -144,8 +144,8 @@ class Submission(_QueryTest):
     def test_submit_dict_problem(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a problem
             linear = {index: random.choice([-1, 1]) for index in solver.nodes}
@@ -157,8 +157,8 @@ class Submission(_QueryTest):
     def test_submit_partial_problem(self):
         """Submit a problem with only some of the terms set."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -180,8 +180,8 @@ class Submission(_QueryTest):
     def test_submit_batch(self):
         """Submit batch of problems."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             result_list = []
             for _ in range(100):
@@ -208,8 +208,8 @@ class Submission(_QueryTest):
     def test_cancel_batch(self):
         """Submit batch of problems, then cancel them."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -241,8 +241,8 @@ class Submission(_QueryTest):
     def test_wait_many(self):
         """Submit a batch of problems then use `wait_multiple` to wait on all of them."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a linear problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -275,8 +275,8 @@ class Submission(_QueryTest):
         all of them."""
 
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
-            solver = client.get_solver(config['solver'])
+        with Client(**config) as client:
+            solver = client.get_solver()
 
             # Build a problem
             linear = [0] * (max(solver.nodes) + 1)
@@ -317,9 +317,9 @@ class DecodingMethod(_QueryTest):
     def test_request_matrix_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             dwave.cloud.computation._numpy = False
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = True
 
             # Build a problem
@@ -333,9 +333,9 @@ class DecodingMethod(_QueryTest):
     def test_request_matrix_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             assert dwave.cloud.computation._numpy
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = True
 
             # Build a problem
@@ -351,9 +351,9 @@ class DecodingMethod(_QueryTest):
     def test_request_list_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             dwave.cloud.computation._numpy = False
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = False
 
             # Build a problem
@@ -366,9 +366,9 @@ class DecodingMethod(_QueryTest):
     def test_request_list_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             assert dwave.cloud.computation._numpy
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = False
 
             # Build a problem
@@ -381,9 +381,9 @@ class DecodingMethod(_QueryTest):
     def test_request_raw_matrix_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             dwave.cloud.computation._numpy = False
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = True
 
             # Build a problem
@@ -397,9 +397,9 @@ class DecodingMethod(_QueryTest):
     def test_request_raw_matrix_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             assert dwave.cloud.computation._numpy
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = True
 
             # Build a problem
@@ -415,9 +415,9 @@ class DecodingMethod(_QueryTest):
     def test_request_raw_list_with_no_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             dwave.cloud.computation._numpy = False
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = False
 
             # Build a problem
@@ -430,9 +430,9 @@ class DecodingMethod(_QueryTest):
     def test_request_raw_list_with_numpy(self):
         """Submit a problem using a dict for the linear terms."""
         # Connect
-        with Client(config['endpoint'], config['token']) as client:
+        with Client(**config) as client:
             assert dwave.cloud.computation._numpy
-            solver = client.get_solver(config['solver'])
+            solver = client.get_solver()
             solver.return_matrix = False
 
             # Build a problem


### PR DESCRIPTION
Config used for live (SAPI integration) tests is now under full control of the caller (through environment variables). Also, the complete config is passed to Client, not only a subset, enabling the use of proxy, different default solvers, and other Client-specific custom parameters in future.

This PR sets the stage for performance testing, and enables integration testing on CI (issue #116).