### PR TITLE
Bump to version v0.4.0

### DIFF
--- a/dwave/cloud/package_info.py
+++ b/dwave/cloud/package_info.py
@@ -1,6 +1,6 @@
 __packagename__ = 'dwave-cloud-client'
 __title__ = 'D-Wave Cloud Client'
-__version__ = '0.3.5'
+__version__ = '0.4.0'
 __author__ = 'D-Wave Systems Inc.'
 __description__ = 'A minimal client for interacting with D-Wave cloud resources.'
 __url__ = 'https://github.com/dwavesystems/dwave-cloud-client'


### PR DESCRIPTION
Changes from v0.3.5:

- exponential back-off in problem status poller (1s - 60s)
- use estimated time of problem completion if available
  (defer polling, expose as `Future.eta_min`)
- docs: update and restructure
- misc improvements and bug fixes