### PR TITLE
Set limit on problem submit batch size (closes #190)

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -109,7 +109,8 @@ class Client(object):
     ANY_STATUS_ONGOING = [STATUS_IN_PROGRESS, STATUS_PENDING]
     ANY_STATUS_NO_RESULT = [STATUS_FAILED, STATUS_CANCELLED]
 
-    # Number of problems to include in a status query
+    # Number of problems to include in a submit/status query
+    _SUBMIT_BATCH_SIZE = 20
     _STATUS_QUERY_SIZE = 100
 
     # Number of worker threads for each problem processing task
@@ -761,7 +762,7 @@ class Client(object):
                     break
 
                 ready_problems = [item]
-                while True:
+                while len(ready_problems) < self._SUBMIT_BATCH_SIZE:
                     try:
                         ready_problems.append(self._submission_queue.get_nowait())
                     except queue.Empty:


### PR DESCRIPTION
Better solution would be to tally actual problem size when encoded
(which includes custom parameters, not only h/J), but a naive
implementation of that with FIFO problem queue would mutate submit
order. One solution would be to switch to priority queue for problems,
with problem sequence number as priority.