### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/dwave/cloud/package_info.py
+++ b/dwave/cloud/package_info.py
@@ -1,6 +1,6 @@
 __packagename__ = 'dwave-cloud-client'
 __title__ = 'D-Wave Cloud Client'
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 __author__ = 'D-Wave Systems Inc.'
 __description__ = 'A minimal client for interacting with D-Wave cloud resources.'
 __url__ = 'https://github.com/dwavesystems/dwave-cloud-client'


### PR DESCRIPTION
Changes from v0.4.3:

- improved API for `Client.get_solver()`: returns sensible default even
  if user hasn't provided one
- fixed CLI/`dwave config create` default input (GNU readline in python
  properly supported only on GNU/Linux)