### PR TITLE
Fix zero-length solver def json parsing

### DIFF
--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -304,7 +304,7 @@ def solvers(config_file, profile, solver_def, list_solvers):
     """Get solver details.
 
     Unless solver name/id specified, fetch and display details for
-    all solvers available on configured endpoint.
+    all online solvers available on the configured endpoint.
     """
 
     with Client.from_config(

--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -345,7 +345,7 @@ class Client(object):
             endpoint, token, solver, proxy, permissive_ssl, request_timeout, polling_timeout, kwargs
         )
 
-        if solver is None:
+        if not solver:
             solver_def = {}
 
         elif isinstance(solver, collections.Mapping):


### PR DESCRIPTION
Essentially, ignore `solver =` lines in config file, or 'DWAVE_SOLVER='
env var values.