### PR TITLE
Add explicit exception for when the problem does not match the solver

### DIFF
--- a/dwave/cloud/exceptions.py
+++ b/dwave/cloud/exceptions.py
@@ -63,3 +63,7 @@ class CanceledFutureError(Exception):
 
 class InvalidAPIResponseError(Exception):
     """Raised when an invalid/unexpected response from D-Wave Solver API is received."""
+
+
+class InvalidProblemError(ValueError):
+    """Solver cannot handle the given binary quadratic model."""

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -358,7 +358,7 @@ class Solver(object):
         """
         # Check the problem
         if not self.check_problem(linear, quadratic):
-            raise ValueError("Problem graph incompatible with solver.")
+            raise InvalidProblemError("Problem graph incompatible with solver.")
 
         # Mix the new parameters with the default parameters
         combined_params = dict(self._params)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -136,7 +136,7 @@ class Submission(_QueryTest):
             linear, quad = generate_random_ising_problem(solver)
             linear[max(solver.nodes) + 1] = 1
 
-            with self.assertRaises(ValueError):
+            with self.assertRaises(InvalidProblemError):
                 results = solver.sample_ising(linear, quad)
                 results.samples
 


### PR DESCRIPTION
Note that without the `solver.check_problem` step the cloud client fails silently for problems that do not match.  This is because `encode_bqm_as_qp` essentially does a
```
[h.get(q, 0) for q in qubits]
```
which means values that are not known qubits are ignored.