### PR TITLE
Use the new solver property, `category`

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -775,8 +775,8 @@ class Client(object):
         Derived properies are:
 
         * `name` (str): Solver name/id.
-        * `qpu` (bool): Is solver QPU based?
-        * `software` (bool): Is solver software based?
+        * `qpu` (bool): Solver is a QPU?
+        * `software` (bool): Solver is a software solver?
         * `online` (bool, default=True): Is solver online?
         * `num_active_qubits` (int): Number of active qubits. Less then or equal to `num_qubits`.
         * `avg_load` (float): Solver's average load (similar to Unix load average).

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -205,14 +205,12 @@ class BaseSolver(object):
     @property
     def qpu(self):
         "Is this a QPU-based solver?"
-        # TODO: add a field for this in SAPI response; for now base decision on id/name
-        return not self.id.startswith('c4-sw_')
+        return self.properties.get('category', '').lower() == 'qpu'
 
     @property
     def software(self):
         "Is this a software-based solver?"
-        # TODO: add a field for this in SAPI response; for now base decision on id/name
-        return self.id.startswith('c4-sw_')
+        return self.properties.get('category', '').lower() == 'software'
 
     @property
     def is_qpu(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -280,6 +280,7 @@ class FeatureBasedSolverSelection(unittest.TestCase):
                     "type": "chimera",
                     "shape": [16, 16, 4]
                 },
+                "category": "qpu",
                 "tags": ["lower_noise"]
             },
             "id": "solver1",
@@ -302,6 +303,7 @@ class FeatureBasedSolverSelection(unittest.TestCase):
                     "type": "pegasus",
                     "shape": [6, 6, 12]
                 },
+                "category": "qpu",
                 "vfyc": True
             },
             "id": "solver2",
@@ -320,6 +322,7 @@ class FeatureBasedSolverSelection(unittest.TestCase):
                     "type": "chimera",
                     "shape": [4, 4, 4]
                 },
+                "category": "software",
                 # the following are only present in this solver
                 "some_set": [1, 2],
                 "some_range": [1, 2],

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -44,6 +44,7 @@ class TestEventDispatch(unittest.TestCase):
                     "type": "chimera",
                     "shape": [16, 16, 4]
                 },
+                "category": "qpu",
                 "tags": ["lower_noise"]
             },
             "id": "solver1",


### PR DESCRIPTION
With `category` we finally can reliably differentiate between qpu
and software solvers.