### PR TITLE
Fix doctest fails in computation & config.py

### DIFF
--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -407,7 +407,7 @@ class Future(object):
             >>> computation = solver.sample_qubo(Q, num_reads=100)   # doctest: +SKIP
             >>> computation.wait(timeout=10)    # doctest: +SKIP
             False
-            >>> computation.remote_status
+            >>> computation.remote_status        # doctest: +SKIP
             'IN_PROGRESS'
             >>> computation.wait(timeout=10)    # doctest: +SKIP
             True

--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -85,9 +85,9 @@ class Future(object):
 
         >>> from dwave.cloud import Client
         >>> client = Client.from_config()
-        >>> solver = client.get_solver()
-        >>> u, v = next(iter(solver.edges))
-        >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}
+        >>> solver = client.get_solver()        # doctest: +SKIP
+        >>> u, v = next(iter(solver.edges))     # doctest: +SKIP
+        >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}   # doctest: +SKIP
         >>> computation = solver.sample_qubo(Q, num_reads=100)   # doctest: +SKIP
         >>> computation.done()  # doctest: +SKIP
         False
@@ -259,9 +259,9 @@ class Future(object):
 
             >>> import dwave.cloud as dc
             >>> client = dc.Client.from_config()
-            >>> solver = client.get_solver()
-            >>> u, v = next(iter(solver.edges))
-            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}
+            >>> solver = client.get_solver()      # doctest: +SKIP
+            >>> u, v = next(iter(solver.edges))   # doctest: +SKIP
+            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}    # doctest: +SKIP
             >>> computation = [solver.sample_qubo(Q, num_reads=1000),
             ...                solver.sample_qubo(Q, num_reads=50),
             ...                solver.sample_qubo(Q, num_reads=10)]   # doctest: +SKIP
@@ -356,9 +356,9 @@ class Future(object):
 
             >>> import dwave.cloud as dc
             >>> client = dc.Client.from_config()
-            >>> solver = client.get_solver()
-            >>> u, v = next(iter(solver.edges))
-            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}
+            >>> solver = client.get_solver()       # doctest: +SKIP
+            >>> u, v = next(iter(solver.edges))    # doctest: +SKIP
+            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}    # doctest: +SKIP
             >>> computation = [solver.sample_qubo(Q, num_reads=1000),
             ...                solver.sample_qubo(Q, num_reads=50),
             ...                solver.sample_qubo(Q, num_reads=10)]   # doctest: +SKIP
@@ -401,9 +401,9 @@ class Future(object):
 
             >>> from dwave.cloud import Client
             >>> client = Client.from_config()
-            >>> solver = client.get_solver()
-            >>> u, v = next(iter(solver.edges))
-            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}
+            >>> solver = client.get_solver()          # doctest: +SKIP
+            >>> u, v = next(iter(solver.edges))       # doctest: +SKIP
+            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}  # doctest: +SKIP
             >>> computation = solver.sample_qubo(Q, num_reads=100)   # doctest: +SKIP
             >>> computation.wait(timeout=10)    # doctest: +SKIP
             False
@@ -434,9 +434,9 @@ class Future(object):
 
             >>> from dwave.cloud import Client
             >>> client = Client.from_config()
-            >>> solver = client.get_solver()
-            >>> u, v = next(iter(solver.edges))
-            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}
+            >>> solver = client.get_solver()        # doctest: +SKIP
+            >>> u, v = next(iter(solver.edges))     # doctest: +SKIP
+            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}    # doctest: +SKIP
             >>> computation = solver.sample_qubo(Q, num_reads=100)   # doctest: +SKIP
             >>> computation.done()  # doctest: +SKIP
             False
@@ -460,9 +460,9 @@ class Future(object):
 
             >>> from dwave.cloud import Client
             >>> client = Client.from_config()
-            >>> solver = client.get_solver()
-            >>> u, v = next(iter(solver.edges))
-            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}
+            >>> solver = client.get_solver()          # doctest: +SKIP
+            >>> u, v = next(iter(solver.edges))       # doctest: +SKIP
+            >>> Q = {(u, u): -1, (u, v): 0, (v, u): 2, (v, v): -1}   # doctest: +SKIP
             >>> computation = solver.sample_qubo(Q, num_reads=100)   # doctest: +SKIP
             >>> computation.cancel()  # doctest: +SKIP
             >>> computation.done()   # doctest: +SKIP
@@ -792,10 +792,10 @@ class Future(object):
             prints timing information for the job.
 
             >>> from dwave.cloud import Client
-            >>> with Client.from_config() as client:
+            >>> with Client.from_config() as client:      # doctest: +SKIP
             ...     solver = client.get_solver()
             ...     u, v = next(iter(solver.edges))
-            ...     computation = solver.sample_ising({u: -1, v: 1},{}, num_reads=5)   # doctest: +SKIP
+            ...     computation = solver.sample_ising({u: -1, v: 1},{}, num_reads=5)
             ...     print(computation.timing)
             ...
             {'total_real_time': 10961, 'anneal_time_per_run': 20, ...}

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -738,7 +738,7 @@ def load_config(config_file=None, profile=None, client=None,
         in the home directory of a Windows system user.
 
         >>> from dwave.cloud import config
-        >>> config.load_config()
+        >>> config.load_config()         # doctest: +SKIP
         {'client': 'qpu',
          'endpoint': 'https://url.of.some.dwavesystem.com/sapi',
          'proxy': None,
@@ -746,7 +746,7 @@ def load_config(config_file=None, profile=None, client=None,
          'token': 'DEF-987654321987654321987654321',
          'headers': None}
         >>> See which configuration file was loaded
-        >>> config.get_configfile_paths()
+        >>> config.get_configfile_paths()             # doctest: +SKIP
         ['C:\\Users\\jane\\AppData\\Local\\dwavesystem\\dwave\\dwave.conf']
 
         Additional examples are given in :mod:`dwave.cloud.config`.

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -89,14 +89,14 @@ Examples:
     >>> from dwave.cloud import Client
     >>> client = Client.from_config(config_file='~/jane/my_path_to_config/my_cloud_conf.conf')  # doctest: +SKIP
     >>> # code that uses client
-    >>> client.close()
+    >>> client.close()   # doctest: +SKIP
 
     This second example auto-detects a configuration file on the local system following the
     user/system configuration paths of :func:`get_configfile_paths`. It passes through
     to the instantiated client an unrecognized key-value pair my_param=`my_value`.
 
     >>> from dwave.cloud import Client
-    >>> client = Client.from_config(my_param=`my_value`)
+    >>> client = Client.from_config(my_param="my_value")
     >>> # code that uses client
     >>> client.close()
 


### PR DESCRIPTION
Part of a fix for doctest failures in the SDK. There might be more that could fail on other runs so I might still update this PR if I have time to go through all of the examples before next updates of SDK submodules.
This is the short-term fix but long-term I want to mock samplers to extend coverage of doctests.