### PR TITLE
Annotate Future.sampleset with .wait_id method

### DIFF
--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -825,6 +825,10 @@ class Future(object):
             energy=self.energies, num_occurrences=self.num_occurrences,
             info=info, sort_labels=True)
 
+        # the id is stored in the info field, but to be consistent with
+        # the samplesets constructed .from_future, we add the method as well
+        sampleset.wait_id = self.wait_id
+
         # this means that samplesets retrieved BEFORE this function are called
         # are not the same object as after, but it is a simpler implementation
         self._result['sampleset'] = self._sampleset = sampleset
@@ -833,7 +837,11 @@ class Future(object):
 
     @property
     def sampleset(self):
-        """Return :class:`~dimod.SampleSet` representation of the results."""
+        """Return :class:`~dimod.SampleSet` representation of the results.
+
+        Adds a `.wait_id` method to retrieve the id before the sampleset is
+        resolved.
+        """
 
         try:
             return self._sampleset
@@ -848,6 +856,9 @@ class Future(object):
 
         self._sampleset = sampleset = dimod.SampleSet.from_future(
             self, lambda f: f.wait_sampleset())
+
+        # propagate id to sampleset as well
+        sampleset.wait_id = self.wait_id
 
         return sampleset
 

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -36,6 +36,11 @@ try:
 except ImportError:
     dimod = None
 
+try:
+    import dimod
+except ImportError:
+    dimod = None
+
 from dwave.cloud.utils import evaluate_ising, generate_const_ising_problem
 from dwave.cloud.client import Client, Solver
 from dwave.cloud.computation import Future
@@ -907,6 +912,22 @@ class TestComputationID(unittest.TestCase):
                 # verify the id is now available
                 self.assertEqual(future.wait_id(), submission_id)
 
+    @unittest.skipUnless(dimod, "dimod required for 'Solver.sample_bqm'")
+    def test_sampleset_id(self):
+        f = Future(solver=None, id_=None)
+
+        # f.id should be None
+        self.assertIsNone(f.id)
+        with self.assertRaises(TimeoutError):
+            f.sampleset.wait_id(timeout=1)
+
+        # set it
+        submission_id = 'test-id'
+        f.id = submission_id
+
+        # validate it's available
+        self.assertEqual(f.sampleset.wait_id(), submission_id)
+        self.assertEqual(f.sampleset.wait_id(timeout=1), submission_id)
 
 @mock.patch('time.sleep', lambda *x: None)
 class TestOffsetHandling(_QueryTest):

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -233,6 +233,9 @@ class Submission(_QueryTest):
             response = solver.sample_bqm(bqm, num_reads=100)
             sampleset = response.sampleset
 
+            self.assertEqual(sampleset.wait_id(), sampleset.info['problem_id'])
+            self.assertEqual(response.id, sampleset.info['problem_id'])
+
             # Did we get the right number of samples?
             self.assertEqual(100, sum(response.num_occurrences))
 
@@ -254,6 +257,9 @@ class Submission(_QueryTest):
             bqm = dimod.BinaryQuadraticModel.from_qubo(quad, offset)
             response = solver.sample_bqm(bqm, num_reads=100)
             sampleset = response.sampleset
+
+            self.assertEqual(sampleset.wait_id(), sampleset.info['problem_id'])
+            self.assertEqual(response.id, sampleset.info['problem_id'])
 
             # Did we get the right number of samples?
             self.assertEqual(100, sum(response.num_occurrences))


### PR DESCRIPTION
Part of https://github.com/dwavesystems/dwave-system/issues/284. Enables the workflow
```
sampleset = LeapHybridSampler().sample(bqm)
id_ = sampleset.wait_id()
```