### PR TITLE
Add hybrid client subclass

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -248,9 +248,10 @@ class Client(object):
                    section is promoted and selected.
 
             client (str, default=None):
-                Client type used for accessing the API. Supported values are ``qpu``
-                for :class:`dwave.cloud.qpu.Client` and ``sw`` for
-                :class:`dwave.cloud.sw.Client`.
+                Client type used for accessing the API. Supported values are
+                ``qpu`` for :class:`dwave.cloud.qpu.Client`, ``sw`` for
+                :class:`dwave.cloud.sw.Client` and ``hybrid`` for
+                :class:`dwave.cloud.hybrid.Client`.
 
             endpoint (str, default=None):
                 API endpoint URL.
@@ -292,8 +293,8 @@ class Client(object):
                 configuration file.
 
         Returns:
-            :class:`~dwave.cloud.client.Client` (:class:`dwave.cloud.qpu.Client` or :class:`dwave.cloud.sw.Client`, default=:class:`dwave.cloud.qpu.Client`):
-                Appropriate instance of a QPU or software client.
+            :class:`~dwave.cloud.client.Client` subclass:
+                Appropriate instance of a QPU/software/hybrid client.
 
         Raises:
             :exc:`~dwave.cloud.exceptions.ConfigFileReadError`:
@@ -339,8 +340,13 @@ class Client(object):
         # manual override of other (client-custom) arguments
         config.update(kwargs)
 
-        from dwave.cloud import qpu, sw
-        _clients = {'qpu': qpu.Client, 'sw': sw.Client, 'base': cls}
+        from dwave.cloud import qpu, sw, hybrid
+        _clients = {
+            'base': cls,
+            'qpu': qpu.Client,
+            'sw': sw.Client,
+            'hybrid': hybrid.Client,
+        }
         _client = config.pop('client', None) or 'base'
 
         logger.debug("Final config used for %s.Client(): %r", _client, config)
@@ -823,9 +829,9 @@ class Client(object):
 
         Note:
             Client subclasses (e.g. :class:`dwave.cloud.qpu.Client` or
-            :class:`dwave.cloud.sw.Client`) already filter solvers by resource
-            type, so for `qpu` and `software` filters to have effect, call :meth:`.get_solvers`
-            on base class :class:`~dwave.cloud.client.Client`.
+            :class:`dwave.cloud.hybrid.Client`) already filter solvers by resource
+            type, so for `qpu` and `hybrid` filters to have effect, call :meth:`.get_solvers`
+            on base :class:`~dwave.cloud.client.Client` class.
 
         Examples::
 

--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -730,8 +730,8 @@ class Client(object):
         Feature `<name>` can be:
 
         1) a derived solver property, available as an identically named
-           :class:`Solver`'s property (`name`, `qpu`, `software`, `online`,
-           `num_active_qubits`, `avg_load`)
+           :class:`Solver`'s property (`name`, `qpu`, `hybrid`, `software`,
+           `online`, `num_active_qubits`, `avg_load`)
         2) a solver parameter, available in :obj:`Solver.parameters`
         3) a solver property, available in :obj:`Solver.properties`
         4) a path describing a property in nested dictionaries

--- a/dwave/cloud/hybrid.py
+++ b/dwave/cloud/hybrid.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 """
-Interface to hybrid :term:`sampler`s available through the D-Wave API.
+Interface to hybrid :term:`sampler`\ s available through the D-Wave Solver API
+(SAPI).
 """
 
 from __future__ import absolute_import
@@ -26,8 +27,8 @@ __all__ = ['Client']
 
 
 class Client(BaseClient):
-    """D-Wave API client specialized to work only with remote hybrid
-    quantum-classical solvers (samplers).
+    """D-Wave Solver API client specialized to work only with remote hybrid
+    quantum-classical solvers.
 
     This class can be instantiated explicitly, or via (base) Client's factory
     method, :meth:`~dwave.cloud.client.Client.from_config` by supplying

--- a/dwave/cloud/hybrid.py
+++ b/dwave/cloud/hybrid.py
@@ -1,0 +1,71 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Interface to hybrid :term:`sampler`s available through the D-Wave API.
+"""
+
+from __future__ import absolute_import
+
+from dwave.cloud.client import Client as BaseClient
+from dwave.cloud.solver import UnstructuredSolver as Solver
+from dwave.cloud.computation import Future
+
+__all__ = ['Client']
+
+
+class Client(BaseClient):
+    """D-Wave API client specialized to work only with remote hybrid
+    quantum-classical solvers (samplers).
+
+    This class can be instantiated explicitly, or via (base) Client's factory
+    method, :meth:`~dwave.cloud.client.Client.from_config` by supplying
+    ``"hybrid"`` for ``client``.
+
+    Examples:
+        This example explicitly instantiates a :class:`dwave.cloud.hybrid.Client`.
+        :meth:`~dwave.cloud.client.Client.get_solver` is guaranteed to return a
+        hybrid quantum-classical solver.
+
+        .. code-block:: python
+
+            from dwave.cloud.hybrid import Client
+
+            with Client(token='...') as client:
+                solver = client.get_solver()
+                response = solver.sample_bqm(...)
+
+        The following example instantiates a hybrid client indirectly. Again,
+        :meth:`~dwave.cloud.client.Client.get_solver`/
+        :meth:`~dwave.cloud.client.Client.get_solvers` are guaranteed to return
+        only hybrid solver(s).
+
+        .. code-block:: python
+
+            from dwave.cloud import Client
+
+            with Client.from_config(client='hybrid') as client:
+                solver = client.get_solver()
+                response = solver.sample_bqm(...)
+
+    """
+
+    @staticmethod
+    def is_solver_handled(solver):
+        """Determine if the specified solver should be handled by this client.
+
+        This predicate function (used from the base class) allows only remote
+        hybrid quantum-classical solvers.
+        """
+        return solver and solver.hybrid

--- a/dwave/cloud/qpu.py
+++ b/dwave/cloud/qpu.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-An implementation of the REST API for D-Wave Solver API (SAPI) servers.
+An implementation of the REST client for D-Wave Solver API (SAPI) service.
 
 SAPI servers provide authentication, queuing, and scheduling services,
 and provide a network interface to :term:`solver`\ s. This API enables you submit
@@ -38,7 +38,7 @@ from dwave.cloud.computation import Future
 __all__ = ['Client']
 
 class Client(BaseClient):
-    """D-Wave API client specialized to work only with QPU solvers.
+    """D-Wave Solver API client specialized to work only with QPU solvers.
 
     This class can be instantiated explicitly, or via (base) Client's factory
     method, :meth:`~dwave.cloud.client.Client.from_config` by supplying

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -217,17 +217,20 @@ class BaseSolver(object):
 
     @property
     def is_qpu(self):
-        warnings.warn("'is_qpu' property is deprecated in favor of 'qpu'.", DeprecationWarning)
+        warnings.warn("'is_qpu' property is deprecated in favor of 'qpu'."
+                      "It will be removed in 0.8.0.", DeprecationWarning)
         return self.qpu
 
     @property
     def is_software(self):
-        warnings.warn("'is_software' property is deprecated in favor of 'software'.", DeprecationWarning)
+        warnings.warn("'is_software' property is deprecated in favor of 'software'."
+                      "It will be removed in 0.8.0.", DeprecationWarning)
         return self.software
 
     @property
     def is_online(self):
-        warnings.warn("'is_online' property is deprecated in favor of 'online'.", DeprecationWarning)
+        warnings.warn("'is_online' property is deprecated in favor of 'online'."
+                      "It will be removed in 0.8.0.", DeprecationWarning)
         return self.online
 
 

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -133,7 +133,7 @@ class BaseSolver(object):
 
         # Derived solver properties (not present in solver data properties dict)
         self.derived_properties = {
-            'qpu', 'software', 'online', 'avg_load', 'name'
+            'qpu', 'hybrid', 'software', 'online', 'avg_load', 'name'
         }
 
     def __repr__(self):

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -216,6 +216,11 @@ class BaseSolver(object):
         return self.properties.get('category', '').lower() == 'software'
 
     @property
+    def hybrid(self):
+        "Is this a hybrid quantum-classical solver?"
+        return self.properties.get('category', '').lower() == 'hybrid'
+
+    @property
     def is_qpu(self):
         warnings.warn("'is_qpu' property is deprecated in favor of 'qpu'."
                       "It will be removed in 0.8.0.", DeprecationWarning)

--- a/dwave/cloud/sw.py
+++ b/dwave/cloud/sw.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 """
-Interface to software :term:`sampler`s available through the D-Wave API.
+Interface to software :term:`sampler`\ s available through the D-Wave Solver
+API (SAPI).
 
 Software samplers have the same interface (response) as QPU samplers, with
 classical software resources generating samples.
@@ -29,8 +30,8 @@ __all__ = ['Client']
 
 
 class Client(BaseClient):
-    """D-Wave API client specialized to work only with remote software solvers
-    (samplers).
+    """D-Wave Solver API client specialized to work only with remote software
+    solvers.
 
     This class can be instantiated explicitly, or via (base) Client's factory
     method, :meth:`~dwave.cloud.client.Client.from_config` by supplying ``"sw"``

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,7 +30,7 @@ from plucky import merge
 
 from dwave.cloud.config import load_config
 from dwave.cloud.client import Client
-from dwave.cloud.solver import Solver
+from dwave.cloud.solver import StructuredSolver, UnstructuredSolver
 from dwave.cloud.exceptions import (
     SolverAuthenticationError, SolverError, SolverNotFoundError)
 from dwave.cloud.testing import mock
@@ -290,7 +290,7 @@ class FeatureBasedSolverSelection(unittest.TestCase):
 
     def setUp(self):
         # mock solvers
-        self.solver1 = Solver(client=None, data={
+        self.qpu1 = StructuredSolver(client=None, data={
             "properties": {
                 "supported_problem_types": ["qubo", "ising"],
                 "qubits": [0, 1, 2],
@@ -308,11 +308,11 @@ class FeatureBasedSolverSelection(unittest.TestCase):
                 "category": "qpu",
                 "tags": ["lower_noise"]
             },
-            "id": "solver1",
-            "description": "A test solver 1",
+            "id": "qpu1",
+            "description": "QPU Chimera solver",
             "status": "online"
         })
-        self.solver2 = Solver(client=None, data={
+        self.qpu2 = StructuredSolver(client=None, data={
             "properties": {
                 "supported_problem_types": ["qubo", "ising"],
                 "qubits": [0, 1, 2, 3, 4],
@@ -331,10 +331,10 @@ class FeatureBasedSolverSelection(unittest.TestCase):
                 "category": "qpu",
                 "vfyc": True
             },
-            "id": "solver2",
-            "description": "A test solver 2"
+            "id": "qpu2",
+            "description": "QPU Pegasus solver"
         })
-        self.solver3 = Solver(client=None, data={
+        self.software = StructuredSolver(client=None, data={
             "properties": {
                 "supported_problem_types": ["qubo", "ising"],
                 "qubits": [0, 1],
@@ -358,7 +358,7 @@ class FeatureBasedSolverSelection(unittest.TestCase):
             "description": "A test of software solver",
             "avg_load": 0.7
         })
-        self.solvers = [self.solver1, self.solver2, self.solver3]
+        self.solvers = [self.qpu1, self.qpu2, self.software]
 
         # mock client
         self.client = Client('endpoint', 'token')
@@ -378,125 +378,125 @@ class FeatureBasedSolverSelection(unittest.TestCase):
         self.assertSolvers(self.client.get_solvers(online=False), [])
 
     def test_qpu_software(self):
-        self.assertSolvers(self.client.get_solvers(qpu=True), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(software=False), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(qpu=False), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(software=True), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(qpu=True), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(software=False), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(qpu=False), [self.software])
+        self.assertSolvers(self.client.get_solvers(software=True), [self.software])
 
     def test_name(self):
-        self.assertSolvers(self.client.get_solvers(name='solver1'), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(name='solver2'), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(name='qpu1'), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(name='qpu2'), [self.qpu2])
         self.assertSolvers(self.client.get_solvers(name='solver'), [])
         self.assertSolvers(self.client.get_solvers(name='olver1'), [])
-        self.assertSolvers(self.client.get_solvers(name__regex='.*1'), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(name__regex='.*[12].*'), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(name__regex='solver[12]'), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(name__regex='^solver(1|2)$'), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(name__regex='.*1'), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(name__regex='.*[12].*'), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(name__regex='qpu[12]'), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(name__regex='^qpu(1|2)$'), [self.qpu1, self.qpu2])
 
     def test_num_qubits(self):
-        self.assertSolvers(self.client.get_solvers(num_qubits=5), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(num_active_qubits=2), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(num_active_qubits__in=[2, 3]), [self.solver1, self.solver3])
+        self.assertSolvers(self.client.get_solvers(num_qubits=5), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(num_active_qubits=2), [self.software])
+        self.assertSolvers(self.client.get_solvers(num_active_qubits__in=[2, 3]), [self.qpu1, self.software])
 
     def test_lower_noise_derived_property(self):
-        self.assertSolvers(self.client.get_solvers(lower_noise=True), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(lower_noise=False), [self.solver2, self.solver3])
+        self.assertSolvers(self.client.get_solvers(lower_noise=True), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(lower_noise=False), [self.qpu2, self.software])
 
     def test_parameter_availability_check(self):
-        self.assertSolvers(self.client.get_solvers(postprocess__available=True), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(postprocess=True), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(parameters__contains='flux_biases'), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(postprocess__available=True), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(postprocess=True), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(parameters__contains='flux_biases'), [self.qpu2])
         self.assertSolvers(self.client.get_solvers(parameters__contains='num_reads'), self.solvers)
 
     def test_property_availability_check(self):
-        self.assertSolvers(self.client.get_solvers(vfyc__available=True), [self.solver2, self.solver3])
-        self.assertSolvers(self.client.get_solvers(vfyc__eq=True), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(vfyc=True), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(vfyc__available=True), [self.qpu2, self.software])
+        self.assertSolvers(self.client.get_solvers(vfyc__eq=True), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(vfyc=True), [self.qpu2])
 
         # inverse of vfyc=True
-        self.assertSolvers(self.client.get_solvers(vfyc__in=[False, None]), [self.solver1, self.solver3])
+        self.assertSolvers(self.client.get_solvers(vfyc__in=[False, None]), [self.qpu1, self.software])
 
         # vfyc unavailable or unadvertized
-        self.assertSolvers(self.client.get_solvers(vfyc__available=False), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(vfyc__eq=False), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(vfyc=False), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(vfyc__available=False), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(vfyc__eq=False), [self.software])
+        self.assertSolvers(self.client.get_solvers(vfyc=False), [self.software])
 
         # non-existing params/props have value of None
-        self.assertSolvers(self.client.get_solvers(vfyc__eq=None), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(vfyc=None), [self.solver1])
+        self.assertSolvers(self.client.get_solvers(vfyc__eq=None), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(vfyc=None), [self.qpu1])
 
     def test_availability_combo(self):
         self.assertSolvers(self.client.get_solvers(vfyc=False, flux_biases=True), [])
-        self.assertSolvers(self.client.get_solvers(vfyc=True, flux_biases=True), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(vfyc=True, flux_biases=True), [self.qpu2])
 
     def test_relational_ops(self):
-        self.assertSolvers(self.client.get_solvers(num_qubits=3), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(num_qubits__eq=3), [self.solver1])
+        self.assertSolvers(self.client.get_solvers(num_qubits=3), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(num_qubits__eq=3), [self.qpu1])
         self.assertSolvers(self.client.get_solvers(num_qubits=4), [])
-        self.assertSolvers(self.client.get_solvers(num_qubits=5), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(num_qubits=5), [self.qpu2])
 
         self.assertSolvers(self.client.get_solvers(num_qubits__gte=2), self.solvers)
-        self.assertSolvers(self.client.get_solvers(num_qubits__gte=5), [self.solver2, self.solver3])
-        self.assertSolvers(self.client.get_solvers(num_qubits__gt=5), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(num_qubits__gte=5), [self.qpu2, self.software])
+        self.assertSolvers(self.client.get_solvers(num_qubits__gt=5), [self.software])
 
         self.assertSolvers(self.client.get_solvers(num_qubits__lte=8), self.solvers)
         self.assertSolvers(self.client.get_solvers(num_qubits__lte=7), self.solvers)
-        self.assertSolvers(self.client.get_solvers(num_qubits__lt=7), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(num_qubits__lt=7), [self.qpu1, self.qpu2])
 
         # skip solver if LHS value not defined (None)
-        self.assertSolvers(self.client.get_solvers(avg_load__gt=0), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load__gte=0), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load__lt=1), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load__lte=1), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load=0.7), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load__eq=0.7), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load=None), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(avg_load__eq=None), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(avg_load__gt=0), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load__gte=0), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load__lt=1), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load__lte=1), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load=0.7), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load__eq=0.7), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load=None), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(avg_load__eq=None), [self.qpu1, self.qpu2])
 
     def test_range_ops(self):
         # value within range
         self.assertSolvers(self.client.get_solvers(num_qubits__within=[3, 7]), self.solvers)
-        self.assertSolvers(self.client.get_solvers(num_qubits__within=[3, 5]), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(num_qubits__within=[2, 4]), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(num_qubits__within=(2, 4)), [self.solver1])
-        self.assertSolvers(self.client.get_solvers(num_qubits__within=(4, 2)), [self.solver1])
+        self.assertSolvers(self.client.get_solvers(num_qubits__within=[3, 5]), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(num_qubits__within=[2, 4]), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(num_qubits__within=(2, 4)), [self.qpu1])
+        self.assertSolvers(self.client.get_solvers(num_qubits__within=(4, 2)), [self.qpu1])
 
         # range within (covered by) range
-        self.assertSolvers(self.client.get_solvers(num_reads_range__within=(0, 500)), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(num_reads_range__within=(0, 500)), [self.qpu1, self.qpu2])
         self.assertSolvers(self.client.get_solvers(num_reads_range__within=(1, 500)), [])
 
         # invalid LHS
-        self.assertSolvers(self.client.get_solvers(some_range__within=[0, 2]), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(some_range__within=[0, 2]), [self.software])
 
         # range covering a value (value included in range)
         self.assertSolvers(self.client.get_solvers(num_reads_range__covers=0), self.solvers)
-        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=150), [self.solver2, self.solver3])
-        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=550), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=1000), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=150), [self.qpu2, self.software])
+        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=550), [self.software])
+        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=1000), [self.software])
         self.assertSolvers(self.client.get_solvers(num_reads_range__covers=1001), [])
 
         # range covering a range
         self.assertSolvers(self.client.get_solvers(num_reads_range__covers=(10, 90)), self.solvers)
-        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=(110, 200)), [self.solver2, self.solver3])
+        self.assertSolvers(self.client.get_solvers(num_reads_range__covers=(110, 200)), [self.qpu2, self.software])
 
         # invalid LHS
-        self.assertSolvers(self.client.get_solvers(some_range__covers=1.5), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(some_range__covers=1.5), [self.software])
 
     def test_membership_ops(self):
         # property contains
         self.assertSolvers(self.client.get_solvers(supported_problem_types__contains="qubo"), self.solvers)
         self.assertSolvers(self.client.get_solvers(supported_problem_types__contains="undef"), [])
         self.assertSolvers(self.client.get_solvers(couplers__contains=[0, 1]), self.solvers)
-        self.assertSolvers(self.client.get_solvers(couplers__contains=[0, 2]), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(couplers__contains=[0, 2]), [self.qpu1, self.qpu2])
 
         # property in
-        self.assertSolvers(self.client.get_solvers(num_qubits__in=[3, 5]), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(num_qubits__in=[7]), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(num_qubits__in=[3, 5]), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(num_qubits__in=[7]), [self.software])
         self.assertSolvers(self.client.get_solvers(num_qubits__in=[]), [])
 
         # invalid LHS
-        self.assertSolvers(self.client.get_solvers(some_set__contains=1), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(avg_load__in=[None]), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(some_set__contains=1), [self.software])
+        self.assertSolvers(self.client.get_solvers(avg_load__in=[None]), [self.qpu1, self.qpu2])
         self.assertSolvers(self.client.get_solvers(avg_load__in=[None, 0.7]), self.solvers)
 
     def test_set_ops(self):
@@ -509,18 +509,18 @@ class FeatureBasedSolverSelection(unittest.TestCase):
 
         # property issuperset
         self.assertSolvers(self.client.get_solvers(qubits__issuperset={0, 1}), self.solvers)
-        self.assertSolvers(self.client.get_solvers(qubits__issuperset={1, 2}), [self.solver1, self.solver2])
+        self.assertSolvers(self.client.get_solvers(qubits__issuperset={1, 2}), [self.qpu1, self.qpu2])
 
         # unhashable types
         self.assertSolvers(self.client.get_solvers(couplers__issuperset=[[0, 1]]), self.solvers)
         self.assertSolvers(self.client.get_solvers(couplers__issuperset={(0, 1)}), self.solvers)
-        self.assertSolvers(self.client.get_solvers(couplers__issuperset={(0, 1), (0, 2)}), [self.solver1, self.solver2])
-        self.assertSolvers(self.client.get_solvers(couplers__issuperset={(0, 1), (0, 2), (2, 3)}), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(couplers__issuperset={(0, 1), (0, 2)}), [self.qpu1, self.qpu2])
+        self.assertSolvers(self.client.get_solvers(couplers__issuperset={(0, 1), (0, 2), (2, 3)}), [self.qpu2])
         self.assertSolvers(self.client.get_solvers(couplers__issuperset={(0, 1), (0, 2), (2, 3), (0, 5)}), [])
 
         # invalid LHS
-        self.assertSolvers(self.client.get_solvers(some_set__issubset={0, 1, 2}), [self.solver3])
-        self.assertSolvers(self.client.get_solvers(some_set__issuperset={1}), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(some_set__issubset={0, 1, 2}), [self.software])
+        self.assertSolvers(self.client.get_solvers(some_set__issuperset={1}), [self.software])
 
     def test_regex(self):
         self.assertSolvers(self.client.get_solvers(num_reads__regex='.*number.*'), [])
@@ -529,29 +529,29 @@ class FeatureBasedSolverSelection(unittest.TestCase):
         self.assertSolvers(self.client.get_solvers(num_reads__regex='Number'), [])
 
         # invalid LHS
-        self.assertSolvers(self.client.get_solvers(some_string__regex='x'), [self.solver3])
+        self.assertSolvers(self.client.get_solvers(some_string__regex='x'), [self.software])
 
     def test_range_boolean_combo(self):
         self.assertSolvers(self.client.get_solvers(num_qubits=3, vfyc=True), [])
-        self.assertSolvers(self.client.get_solvers(num_qubits__gte=3, vfyc=True), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(num_qubits__gte=3, vfyc=True), [self.qpu2])
         self.assertSolvers(self.client.get_solvers(num_qubits__lte=4, vfyc=True), [])
-        self.assertSolvers(self.client.get_solvers(num_qubits__within=(3, 6), flux_biases=True), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(num_qubits=5, flux_biases=True), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(num_qubits__within=(3, 6), flux_biases=True), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(num_qubits=5, flux_biases=True), [self.qpu2])
 
     def test_nested_properties_leaf_lookup(self):
-        self.assertSolvers(self.client.get_solvers(topology__type="chimera"), [self.solver1, self.solver3])
-        self.assertSolvers(self.client.get_solvers(topology__type="pegasus"), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(topology__type__eq="pegasus"), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(topology__shape=[6,6,12]), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(topology__type="chimera", topology__shape__contains=16), [self.solver1])
+        self.assertSolvers(self.client.get_solvers(topology__type="chimera"), [self.qpu1, self.software])
+        self.assertSolvers(self.client.get_solvers(topology__type="pegasus"), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(topology__type__eq="pegasus"), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(topology__shape=[6,6,12]), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(topology__type="chimera", topology__shape__contains=16), [self.qpu1])
 
     def test_nested_properties_intermediate_key_lookup(self):
         self.assertSolvers(self.client.get_solvers(topology__contains="shape"), self.solvers)
-        self.assertSolvers(self.client.get_solvers(topology={"type": "pegasus", "shape": [6, 6, 12]}), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(topology={"type": "pegasus", "shape": [6, 6, 12]}), [self.qpu2])
 
     def test_anneal_schedule(self):
-        self.assertSolvers(self.client.get_solvers(anneal_schedule__available=True), [self.solver2])
-        self.assertSolvers(self.client.get_solvers(anneal_schedule=True), [self.solver2])
+        self.assertSolvers(self.client.get_solvers(anneal_schedule__available=True), [self.qpu2])
+        self.assertSolvers(self.client.get_solvers(anneal_schedule=True), [self.qpu2])
 
     def test_solvers_deprecation(self):
         with warnings.catch_warnings(record=True) as w:
@@ -562,7 +562,7 @@ class FeatureBasedSolverSelection(unittest.TestCase):
 
     def test_order_by_edgecases(self):
         # default: sort by avg_load
-        self.assertEqual(self.client.get_solvers(), [self.solver3, self.solver1, self.solver2])
+        self.assertEqual(self.client.get_solvers(), [self.software, self.qpu1, self.qpu2])
 
         # explicit no sort
         self.assertEqual(self.client.get_solvers(order_by=None), self.solvers)
@@ -580,21 +580,21 @@ class FeatureBasedSolverSelection(unittest.TestCase):
 
     def test_order_by_string(self):
         # sort by Solver inferred properties
-        self.assertEqual(self.client.get_solvers(order_by='id'), [self.solver3, self.solver1, self.solver2])
-        self.assertEqual(self.client.get_solvers(order_by='qpu'), [self.solver3, self.solver1, self.solver2])
+        self.assertEqual(self.client.get_solvers(order_by='id'), [self.software, self.qpu1, self.qpu2])
+        self.assertEqual(self.client.get_solvers(order_by='qpu'), [self.software, self.qpu1, self.qpu2])
         self.assertEqual(self.client.get_solvers(order_by='num_qubits'), self.solvers)
-        self.assertEqual(self.client.get_solvers(order_by='num_active_qubits'), [self.solver3, self.solver1, self.solver2])
+        self.assertEqual(self.client.get_solvers(order_by='num_active_qubits'), [self.software, self.qpu1, self.qpu2])
 
         # sort by solver property
         self.assertEqual(self.client.get_solvers(order_by='properties.num_qubits'), self.solvers)
 
         # sort (and reverse sort) by upper bound of a range property
         self.assertEqual(self.client.get_solvers(order_by='properties.num_reads_range[1]'), self.solvers)
-        self.assertEqual(self.client.get_solvers(order_by='-properties.num_reads_range[1]'), [self.solver3, self.solver2, self.solver1])
+        self.assertEqual(self.client.get_solvers(order_by='-properties.num_reads_range[1]'), [self.software, self.qpu2, self.qpu1])
 
         # check solvers with None values for key end up last
-        self.assertEqual(self.client.get_solvers(order_by='properties.vfyc'), [self.solver3, self.solver2, self.solver1])
-        self.assertEqual(self.client.get_solvers(order_by='-properties.vfyc'), [self.solver1, self.solver2, self.solver3])
+        self.assertEqual(self.client.get_solvers(order_by='properties.vfyc'), [self.software, self.qpu2, self.qpu1])
+        self.assertEqual(self.client.get_solvers(order_by='-properties.vfyc'), [self.qpu1, self.qpu2, self.software])
 
         # check invalid keys don't fail, and effectively don't sort the list
         self.assertEqual(self.client.get_solvers(order_by='non_existing_key'), self.solvers)
@@ -602,14 +602,14 @@ class FeatureBasedSolverSelection(unittest.TestCase):
 
     def test_order_by_callable(self):
         # sort by Solver inferred properties
-        self.assertEqual(self.client.get_solvers(order_by=lambda solver: solver.id), [self.solver3, self.solver1, self.solver2])
+        self.assertEqual(self.client.get_solvers(order_by=lambda solver: solver.id), [self.software, self.qpu1, self.qpu2])
         self.assertEqual(self.client.get_solvers(order_by=lambda solver: solver.num_qubits), self.solvers)
 
         # sort by solver property
         self.assertEqual(self.client.get_solvers(order_by=lambda solver: solver.properties['num_qubits']), self.solvers)
 
         # sort None`s last (here: False, True, None)
-        self.assertEqual(self.client.get_solvers(order_by=lambda solver: solver.properties.get('vfyc')), [self.solver3, self.solver2, self.solver1])
+        self.assertEqual(self.client.get_solvers(order_by=lambda solver: solver.properties.get('vfyc')), [self.software, self.qpu2, self.qpu1])
 
         # test no sort
         self.assertEqual(self.client.get_solvers(order_by=lambda solver: None), self.solvers)

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -212,24 +212,33 @@ class MockSolverLoading(unittest.TestCase):
         # base client
         self.assertTrue(Client.is_solver_handled(solver_object('test', 'qpu')))
         self.assertTrue(Client.is_solver_handled(solver_object('test', 'software')))
+        self.assertTrue(Client.is_solver_handled(solver_object('test', 'hybrid')))
         self.assertTrue(Client.is_solver_handled(solver_object('test', 'whatever')))
         self.assertTrue(Client.is_solver_handled(None))
         # qpu client
         self.assertTrue(QPUClient.is_solver_handled(solver_object('test', 'qpu')))
         self.assertFalse(QPUClient.is_solver_handled(solver_object('test', 'software')))
+        self.assertFalse(QPUClient.is_solver_handled(solver_object('test', 'hybrid')))
         self.assertFalse(QPUClient.is_solver_handled(solver_object('test', 'whatever')))
         self.assertFalse(QPUClient.is_solver_handled(None))
         # sw client
         self.assertFalse(SoftwareClient.is_solver_handled(solver_object('test', 'qpu')))
         self.assertTrue(SoftwareClient.is_solver_handled(solver_object('test', 'software')))
+        self.assertFalse(SoftwareClient.is_solver_handled(solver_object('test', 'hybrid')))
         self.assertFalse(SoftwareClient.is_solver_handled(solver_object('test', 'whatever')))
         self.assertFalse(SoftwareClient.is_solver_handled(None))
 
     def test_solver_feature_properties(self):
         self.assertTrue(solver_object('solver', 'qpu').qpu)
+        self.assertTrue(solver_object('solver', 'QPU').qpu)
         self.assertFalse(solver_object('solver', 'qpu').software)
+        self.assertFalse(solver_object('solver', 'qpu').hybrid)
         self.assertFalse(solver_object('solver', 'software').qpu)
         self.assertTrue(solver_object('solver', 'software').software)
+        self.assertFalse(solver_object('solver', 'software').hybrid)
+        self.assertTrue(solver_object('solver', 'hybrid').hybrid)
+        self.assertFalse(solver_object('solver', 'hybrid').qpu)
+        self.assertFalse(solver_object('solver', 'hybrid').software)
 
         self.assertFalse(solver_object('solver').is_vfyc)
         self.assertEqual(solver_object('solver').num_qubits, 3)


### PR DESCRIPTION
In this PR, we add:
- `dwave.cloud.hybrid.Client`, a hybrid-solvers-only client subclass
  - enabling hybrid client construction with `from_config` factory via `client="hybrid"`
- `BaseSolver.hybrid` property, enabling feature-based solver filtering via `hybrid` "derived" solver property (e.g. `client.get_solver(hybrid=True)`)