### PR TITLE
Add support for client-side certificate auth

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -376,16 +376,27 @@ class Client(object):
         if not endpoint:
             endpoint = self.DEFAULT_API_ENDPOINT
 
-        if not token:
+        # read optional client certificate
+        client_cert = kwargs.pop('client_cert', None)
+        client_cert_key = kwargs.pop('client_cert_key', None)
+        if client_cert_key is not None:
+            if client_cert is not None:
+                client_cert = (client_cert, client_cert_key)
+            else:
+                raise ValueError(
+                    "Client certificate key given, but the cert is missing")
+
+        # fail without token only if client cert is not used
+        if not client_cert and not token:
             raise ValueError("API token not defined")
 
         logger.debug(
             "Creating a client for (endpoint=%r, token=%r, solver=%r, proxy=%r, "
             "permissive_ssl=%r, request_timeout=%r, polling_timeout=%r, "
-            "connection_close=%r, headers=%r, **kwargs=%r)",
+            "connection_close=%r, headers=%r, client_cert=%r, **kwargs=%r)",
             endpoint, token, solver, proxy,
             permissive_ssl, request_timeout, polling_timeout,
-            connection_close, headers, kwargs
+            connection_close, headers, client_cert, kwargs
         )
 
         # parse solver
@@ -432,6 +443,7 @@ class Client(object):
         self.default_solver = solver_def
 
         self.token = token
+        self.client_cert = client_cert
         self.request_timeout = parse_float(request_timeout)
         self.polling_timeout = parse_float(polling_timeout)
 
@@ -507,10 +519,15 @@ class Client(object):
         session = BaseUrlSession(base_url=endpoint)
         session.mount('http://', TimeoutingHTTPAdapter(timeout=self.request_timeout))
         session.mount('https://', TimeoutingHTTPAdapter(timeout=self.request_timeout))
+
+        session.headers.update({'User-Agent': user_agent(__packagename__, __version__)})
         if self.headers:
             session.headers.update(self.headers)
-        session.headers.update({'X-Auth-Token': self.token,
-                                'User-Agent': user_agent(__packagename__, __version__)})
+        if self.token:
+            session.headers.update({'X-Auth-Token': self.token})
+        if self.client_cert:
+            session.cert = self.client_cert
+
         session.proxies = {'http': self.proxy, 'https': self.proxy}
         if self.permissive_ssl:
             session.verify = False

--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -376,7 +376,10 @@ class Client(object):
         if not endpoint:
             endpoint = self.DEFAULT_API_ENDPOINT
 
-        # read optional client certificate
+        if not token:
+            raise ValueError("API token not defined")
+
+        # parse optional client certificate
         client_cert = kwargs.pop('client_cert', None)
         client_cert_key = kwargs.pop('client_cert_key', None)
         if client_cert_key is not None:
@@ -385,10 +388,6 @@ class Client(object):
             else:
                 raise ValueError(
                     "Client certificate key given, but the cert is missing")
-
-        # fail without token only if client cert is not used
-        if not client_cert and not token:
-            raise ValueError("API token not defined")
 
         logger.debug(
             "Creating a client for (endpoint=%r, token=%r, solver=%r, proxy=%r, "

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -305,6 +305,68 @@ class ClientFactory(unittest.TestCase):
             with dwave.cloud.Client.from_config(headers=headers_str) as client:
                 self.assertDictEqual(client.headers, headers_dict)
 
+    def test_client_cert_from_config(self):
+        crt = '/path/to/crt'
+        key = '/path/to/key'
+
+        # single file with cert+key
+        client_cert = crt
+        conf = dict(client_cert=crt)
+
+        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
+            with dwave.cloud.Client.from_config() as client:
+                self.assertEqual(client.client_cert, client_cert)
+
+                session = client.create_session()
+                self.assertEqual(session.cert, client_cert)
+
+        # separate cert and key files
+        client_cert = (crt, key)
+        conf = dict(client_cert=crt, client_cert_key=key)
+
+        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
+            with dwave.cloud.Client.from_config() as client:
+                self.assertEqual(client.client_cert, client_cert)
+
+                session = client.create_session()
+                self.assertEqual(session.cert, client_cert)
+
+        # single file with cert+key, with token
+        client_cert = crt
+        conf = dict(token='token', client_cert=crt)
+
+        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
+            with dwave.cloud.Client.from_config() as client:
+                self.assertEqual(client.client_cert, client_cert)
+
+    def test_client_cert_from_kwargs(self):
+        crt = '/path/to/crt'
+        key = '/path/to/key'
+
+        # single file with cert+key
+        client_cert = crt
+        conf = dict(client_cert=crt)
+
+        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: {}):
+            with dwave.cloud.Client.from_config(**conf) as client:
+                self.assertEqual(client.client_cert, client_cert)
+
+        # separate cert and key files
+        client_cert = (crt, key)
+        conf = dict(client_cert=crt, client_cert_key=key)
+
+        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: {}):
+            with dwave.cloud.Client.from_config(**conf) as client:
+                self.assertEqual(client.client_cert, client_cert)
+
+        # client_cert as tuple (direct `requests` format)
+        client_cert = (crt, key)
+        conf = dict(client_cert=client_cert)
+
+        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: {}):
+            with dwave.cloud.Client.from_config(**conf) as client:
+                self.assertEqual(client.client_cert, client_cert)
+
 
 class FeatureBasedSolverSelection(unittest.TestCase):
     """Test Client.get_solvers(**filters)."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -311,7 +311,7 @@ class ClientFactory(unittest.TestCase):
 
         # single file with cert+key
         client_cert = crt
-        conf = dict(client_cert=crt)
+        conf = dict(token='token', client_cert=crt)
 
         with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
             with dwave.cloud.Client.from_config() as client:
@@ -322,7 +322,7 @@ class ClientFactory(unittest.TestCase):
 
         # separate cert and key files
         client_cert = (crt, key)
-        conf = dict(client_cert=crt, client_cert_key=key)
+        conf = dict(token='token', client_cert=crt, client_cert_key=key)
 
         with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
             with dwave.cloud.Client.from_config() as client:
@@ -331,23 +331,19 @@ class ClientFactory(unittest.TestCase):
                 session = client.create_session()
                 self.assertEqual(session.cert, client_cert)
 
-        # single file with cert+key, with token
-        client_cert = crt
-        conf = dict(token='token', client_cert=crt)
-
-        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: conf):
-            with dwave.cloud.Client.from_config() as client:
-                self.assertEqual(client.client_cert, client_cert)
-
     def test_client_cert_from_kwargs(self):
         crt = '/path/to/crt'
         key = '/path/to/key'
+
+        def load_config(**kwargs):
+            file_conf = dict(token='token')
+            return merge(kwargs, file_conf, op=lambda a, b: a or b)
 
         # single file with cert+key
         client_cert = crt
         conf = dict(client_cert=crt)
 
-        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: {}):
+        with mock.patch("dwave.cloud.client.load_config", load_config):
             with dwave.cloud.Client.from_config(**conf) as client:
                 self.assertEqual(client.client_cert, client_cert)
 
@@ -355,7 +351,7 @@ class ClientFactory(unittest.TestCase):
         client_cert = (crt, key)
         conf = dict(client_cert=crt, client_cert_key=key)
 
-        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: {}):
+        with mock.patch("dwave.cloud.client.load_config", load_config):
             with dwave.cloud.Client.from_config(**conf) as client:
                 self.assertEqual(client.client_cert, client_cert)
 
@@ -363,7 +359,7 @@ class ClientFactory(unittest.TestCase):
         client_cert = (crt, key)
         conf = dict(client_cert=client_cert)
 
-        with mock.patch("dwave.cloud.client.load_config", lambda **kwargs: {}):
+        with mock.patch("dwave.cloud.client.load_config", load_config):
             with dwave.cloud.Client.from_config(**conf) as client:
                 self.assertEqual(client.client_cert, client_cert)
 


### PR DESCRIPTION
Config/kwarg options added to client:
- `client_cert`
- `client_cert_key`

They both accept a string path to a crt/key file.

If only `client_cert` is given, the file must contain both the certificate
and the key. Alternatively, cert and key can be split among the two
options.

Closes #383.