### PR TITLE
Restore support for solvers without category property

### DIFF
--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -204,17 +204,35 @@ class BaseSolver(object):
     @property
     def qpu(self):
         "Is this a QPU-based solver?"
-        return self.properties.get('category', '').lower() == 'qpu'
+        category = self.properties.get('category', '').lower()
+        if category:
+            return category == 'qpu'
+        else:
+            # fallback for legacy solvers without the `category` property
+            # TODO: remove when all production solvers are updated
+            return not (self.software or self.hybrid)
 
     @property
     def software(self):
         "Is this a software-based solver?"
-        return self.properties.get('category', '').lower() == 'software'
+        category = self.properties.get('category', '').lower()
+        if category:
+            return category == 'software'
+        else:
+            # fallback for legacy solvers without the `category` property
+            # TODO: remove when all production solvers are updated
+            return self.id.startswith('c4-sw_')
 
     @property
     def hybrid(self):
         "Is this a hybrid quantum-classical solver?"
-        return self.properties.get('category', '').lower() == 'hybrid'
+        category = self.properties.get('category', '').lower()
+        if category:
+            return category == 'hybrid'
+        else:
+            # fallback for legacy solvers without the `category` property
+            # TODO: remove when all production solvers are updated
+            return self.id.startswith('hybrid')
 
     @property
     def is_qpu(self):

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -25,6 +25,7 @@ import requests_mock
 from dwave.cloud.client import Client, Solver
 from dwave.cloud.qpu import Client as QPUClient
 from dwave.cloud.sw import Client as SoftwareClient
+from dwave.cloud.hybrid import Client as HybridClient
 from dwave.cloud.exceptions import (
     SolverPropertyMissingError, ConfigFileReadError, ConfigFileParseError,
     SolverError, SolverNotFoundError)
@@ -226,6 +227,12 @@ class MockSolverLoading(unittest.TestCase):
         self.assertFalse(SoftwareClient.is_solver_handled(solver_object('test', 'hybrid')))
         self.assertFalse(SoftwareClient.is_solver_handled(solver_object('test', 'whatever')))
         self.assertFalse(SoftwareClient.is_solver_handled(None))
+        # hybrid client
+        self.assertFalse(HybridClient.is_solver_handled(solver_object('test', 'qpu')))
+        self.assertFalse(HybridClient.is_solver_handled(solver_object('test', 'software')))
+        self.assertTrue(HybridClient.is_solver_handled(solver_object('test', 'hybrid')))
+        self.assertFalse(HybridClient.is_solver_handled(solver_object('test', 'whatever')))
+        self.assertFalse(HybridClient.is_solver_handled(None))
 
     def test_solver_feature_properties(self):
         self.assertTrue(solver_object('solver', 'qpu').qpu)
@@ -282,6 +289,7 @@ class MockSolverLoading(unittest.TestCase):
         # client type filtering support
         self.assertTrue(QPUClient.is_solver_handled(solver_object('solver', cat='')))
         self.assertTrue(SoftwareClient.is_solver_handled(solver_object('c4-sw_x', cat='')))
+        self.assertTrue(HybridClient.is_solver_handled(solver_object('hybrid_x', cat='')))
 
         # derived properties are correct
         self.assertTrue(solver_object('solver', cat='').qpu)

--- a/tests/test_mock_solver_loading.py
+++ b/tests/test_mock_solver_loading.py
@@ -275,6 +275,25 @@ class MockSolverLoading(unittest.TestCase):
         del data['status']
         self.assertTrue(Solver(None, data).online)
 
+    # Test fallback for legacy solvers without the `category` property
+    # TODO: remove when all production solvers are updated
+    def test_solver_with_category_missing(self):
+
+        # client type filtering support
+        self.assertTrue(QPUClient.is_solver_handled(solver_object('solver', cat='')))
+        self.assertTrue(SoftwareClient.is_solver_handled(solver_object('c4-sw_x', cat='')))
+
+        # derived properties are correct
+        self.assertTrue(solver_object('solver', cat='').qpu)
+        self.assertFalse(solver_object('solver', cat='').software)
+        self.assertFalse(solver_object('solver', cat='').hybrid)
+        self.assertFalse(solver_object('c4-sw_x', cat='').qpu)
+        self.assertTrue(solver_object('c4-sw_x', cat='').software)
+        self.assertFalse(solver_object('c4-sw_x', cat='').hybrid)
+        self.assertFalse(solver_object('hybrid_x', cat='').qpu)
+        self.assertFalse(solver_object('hybrid_x', cat='').software)
+        self.assertTrue(solver_object('hybrid_x', cat='').hybrid)
+
 
 class RequestEvent(Exception):
     """Throws exception when mocked client submits an HTTP request."""


### PR DESCRIPTION
Closes #389.

Partially reverts #346 in combination with #379.