### PR TITLE
Expose polling params and make polling faster

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -165,7 +165,7 @@ class Client(object):
     _LOAD_THREAD_COUNT = 5
 
     # Poll back-off schedule defaults [sec]
-    _DEFAULT_POLL_BACKOFF_MIN = 1
+    _DEFAULT_POLL_BACKOFF_MIN = 0.05
     _DEFAULT_POLL_BACKOFF_MAX = 60
 
     # Tolerance for server-client clocks difference (approx) [sec]

--- a/dwave/cloud/config.py
+++ b/dwave/cloud/config.py
@@ -228,14 +228,14 @@ CONF_AUTHOR = "dwavesystem"
 CONF_FILENAME = "dwave.conf"
 
 
-def parse_float(s):
+def parse_float(s, default=None):
     """Parse value as returned by ConfigParse as float.
 
     NB: we need this instead of ``ConfigParser.getfloat`` when we're parsing
     values downstream."""
 
     if s is None or s == '':
-        return None
+        return default
     return float(s)
 
 

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -500,7 +500,7 @@ class MockSubmission(_QueryTest):
                 future.result()
 
                 # after third poll, back-off interval should be 4 x initial back-off
-                self.assertEqual(future._poll_backoff, Client._POLL_BACKOFF_MIN * 2**2)
+                self.assertEqual(future._poll_backoff, client.poll_backoff_min * 2**2)
 
     def test_eta_min_is_ignored_on_first_poll(self):
         "eta_min/earliest_estimated_completion should not be used anymore"
@@ -529,7 +529,7 @@ class MockSubmission(_QueryTest):
 
                 def assert_no_delay(s):
                     s and self.assertTrue(
-                        abs(s - client._POLL_BACKOFF_MIN) < client._POLL_BACKOFF_MIN / 10.0)
+                        abs(s - client.poll_backoff_min) < client.poll_backoff_min / 10.0)
 
                 with mock.patch('time.sleep', assert_no_delay):
                     future = solver.sample_qubo({})
@@ -558,7 +558,7 @@ class MockSubmission(_QueryTest):
 
                 def assert_no_delay(s):
                     s and self.assertTrue(
-                        abs(s - client._POLL_BACKOFF_MIN) < client._POLL_BACKOFF_MIN / 10.0)
+                        abs(s - client.poll_backoff_min) < client.poll_backoff_min / 10.0)
 
                 with mock.patch('time.sleep', assert_no_delay):
                     future = solver.sample_qubo({})
@@ -588,7 +588,7 @@ class MockSubmission(_QueryTest):
 
                 def assert_no_delay(s):
                     s and self.assertTrue(
-                        abs(s - client._POLL_BACKOFF_MIN) < client._POLL_BACKOFF_MIN / 10.0)
+                        abs(s - client.poll_backoff_min) < client.poll_backoff_min / 10.0)
 
                 with mock.patch('time.sleep', assert_no_delay):
                     future = solver.sample_qubo({})
@@ -639,7 +639,7 @@ class MockSubmission(_QueryTest):
                 future.result()
 
                 # after third poll, back-off interval should be 4 x initial back-off
-                self.assertEqual(future._poll_backoff, Client._POLL_BACKOFF_MIN * 2**2)
+                self.assertEqual(future._poll_backoff, client.poll_backoff_min * 2**2)
 
 
 class DeleteEvent(Exception):

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -529,7 +529,7 @@ class MockSubmission(_QueryTest):
 
                 def assert_no_delay(s):
                     s and self.assertTrue(
-                        abs(s - client.poll_backoff_min) < client.poll_backoff_min / 10.0)
+                        abs(s - client.poll_backoff_min) < client._DEFAULT_POLL_BACKOFF_MIN)
 
                 with mock.patch('time.sleep', assert_no_delay):
                     future = solver.sample_qubo({})
@@ -558,7 +558,7 @@ class MockSubmission(_QueryTest):
 
                 def assert_no_delay(s):
                     s and self.assertTrue(
-                        abs(s - client.poll_backoff_min) < client.poll_backoff_min / 10.0)
+                        abs(s - client.poll_backoff_min) < client._DEFAULT_POLL_BACKOFF_MIN)
 
                 with mock.patch('time.sleep', assert_no_delay):
                     future = solver.sample_qubo({})
@@ -588,7 +588,7 @@ class MockSubmission(_QueryTest):
 
                 def assert_no_delay(s):
                     s and self.assertTrue(
-                        abs(s - client.poll_backoff_min) < client.poll_backoff_min / 10.0)
+                        abs(s - client.poll_backoff_min) < client._DEFAULT_POLL_BACKOFF_MIN)
 
                 with mock.patch('time.sleep', assert_no_delay):
                     future = solver.sample_qubo({})


### PR DESCRIPTION
Introduces `poll_backoff_min` and `poll_backoff_max` config/kwarg parameters.

Reduces the default value for `poll_backoff_min` from 1s to 50ms.

Closes #410.