### PR TITLE
Apply energy offset when provided to sampling method

### DIFF
--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -156,6 +156,9 @@ class Future(object):
         # current poll back-off interval, in seconds
         self._poll_backoff = None
 
+        # XXX: energy offset carried via Future, until implemented in SAPI
+        self._offset = 0
+
     # TODO: remove in 0.9.0
     @property
     def error(self):
@@ -878,9 +881,20 @@ class Future(object):
 
         return self._result
 
+    def _patch_offset(self):
+        # XXX: This is a temporary fix, until SAPI starts returning the offset
+        # in answer (for structured solvers only).
+        # It will patch `self._message` to include the offset as set in
+        # `self._offset`.
+        msg = self._message
+        fmt = msg.get('answer', {}).get('format')
+        if fmt == 'qp':
+            msg['answer']['offset'] = self._offset
+
     def _decode(self):
         """Decode answer data from the response."""
         start = time.time()
+        self._patch_offset()
         self._result = self.solver.decode_response(self._message)
         self.parse_time = time.time() - start
         return self._result

--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -885,11 +885,12 @@ class Future(object):
         # XXX: This is a temporary fix, until SAPI starts returning the offset
         # in answer (for structured solvers only).
         # It will patch `self._message` to include the offset as set in
-        # `self._offset`.
+        # `self._offset`, but only if SAPI answer does not contain offset already.
         msg = self._message
         fmt = msg.get('answer', {}).get('format')
         if fmt == 'qp':
-            msg['answer']['offset'] = self._offset
+            if 'offset' not in msg['answer']:
+                msg['answer']['offset'] = self._offset
 
     def _decode(self):
         """Decode answer data from the response."""

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -278,6 +278,16 @@ class UnstructuredSolver(BaseSolver):
         """Sample from the specified :term:`Ising` model.
 
         Args:
+            linear (dict/list):
+                Linear biases of the Ising problem. If a dict, should be of the
+                form `{v: bias, ...}` where v is a spin-valued variable and `bias`
+                is its associated bias. If a list, it is treated as a list of
+                biases where the indices are the variable labels.
+
+            quadratic (dict[(variable, variable), bias]):
+                Quadratic terms of the model (J), stored in a dict. With keys
+                that are 2-tuples of variables and values are quadratic biases
+                associated with the pair of variables (the interaction).
 
             offset (optional, default=0):
                 Constant offset applied to the model.
@@ -306,7 +316,9 @@ class UnstructuredSolver(BaseSolver):
         Args:
             qubo (dict):
                 Coefficients of a quadratic unconstrained binary optimization
-                (QUBO) model.
+                (QUBO) problem. Should be a dict of the form `{(u, v): bias, ...}`
+                where `u`, `v`, are binary-valued variables and `bias` is their
+                associated coefficient.
 
             offset (optional, default=0):
                 Constant offset applied to the model.
@@ -580,8 +592,11 @@ class StructuredSolver(BaseSolver):
         """Sample from the specified :term:`Ising` model.
 
         Args:
-            linear (list/dict):
-                Linear terms of the model (h).
+            linear (dict/list):
+                Linear biases of the Ising problem. If a dict, should be of the
+                form `{v: bias, ...}` where v is a spin-valued variable and `bias`
+                is its associated bias. If a list, it is treated as a list of
+                biases where the indices are the variable labels.
 
             quadratic (dict[(int, int), float]):
                 Quadratic terms of the model (J), stored in a dict. With keys
@@ -629,7 +644,9 @@ class StructuredSolver(BaseSolver):
         Args:
             qubo (dict[(int, int), float]):
                 Coefficients of a quadratic unconstrained binary optimization
-                (QUBO) model.
+                (QUBO) problem. Should be a dict of the form `{(u, v): bias, ...}`
+                where `u`, `v`, are binary-valued variables and `bias` is their
+                associated coefficient.
 
             offset (optional, default=0):
                 Constant offset applied to the model.

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -44,12 +44,13 @@ __all__ = ['evaluate_ising', 'uniform_iterator', 'uniform_get',
 logger = logging.getLogger(__name__)
 
 
-def evaluate_ising(linear, quad, state):
+def evaluate_ising(linear, quad, state, offset=0):
     """Calculate the energy of a state given the Hamiltonian.
 
     Args:
         linear: Linear Hamiltonian terms.
         quad: Quadratic Hamiltonian terms.
+        offset: Energy offset.
         state: Vector of spins describing the system state.
 
     Returns:
@@ -58,10 +59,10 @@ def evaluate_ising(linear, quad, state):
 
     # If we were given a numpy array cast to list
     if _numpy and isinstance(state, np.ndarray):
-        return evaluate_ising(linear, quad, state.tolist())
+        return evaluate_ising(linear, quad, state.tolist(), offset=offset)
 
     # Accumulate the linear and quadratic values
-    energy = 0.0
+    energy = offset
     for index, value in uniform_iterator(linear):
         energy += state[index] * value
     for (index_a, index_b), value in quad.items():
@@ -132,7 +133,7 @@ def uniform_get(sequence, index, default=None):
         return sequence[index] if index < len(sequence) else default
 
 
-def reformat_qubo_as_ising(qubo, offset=0):
+def reformat_qubo_as_ising(qubo, offset=0.0):
     """Split QUBO coefficients into linear and quadratic terms (the Ising form).
 
     Args:
@@ -151,7 +152,7 @@ def reformat_qubo_as_ising(qubo, offset=0):
     lin = {u: bias for (u, v), bias in qubo.items() if u == v}
     quad = {(u, v): bias for (u, v), bias in qubo.items() if u != v}
 
-    return lin, quad, offset
+    return lin, quad, float(offset)
 
 
 def strip_head(sequence, values):

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -132,7 +132,7 @@ def uniform_get(sequence, index, default=None):
         return sequence[index] if index < len(sequence) else default
 
 
-def reformat_qubo_as_ising(qubo):
+def reformat_qubo_as_ising(qubo, offset=0):
     """Split QUBO coefficients into linear and quadratic terms (the Ising form).
 
     Args:
@@ -140,15 +140,18 @@ def reformat_qubo_as_ising(qubo):
             Coefficients of a quadratic unconstrained binary optimization
             (QUBO) model.
 
+        offset (optional, default=0):
+            Constant offset applied to the model.
+
     Returns:
-        (dict[int, float], dict[(int, int), float])
+        (dict[int, float], dict[(int, int), float], float)
 
     """
 
     lin = {u: bias for (u, v), bias in qubo.items() if u == v}
     quad = {(u, v): bias for (u, v), bias in qubo.items() if u != v}
 
-    return lin, quad
+    return lin, quad, offset
 
 
 def strip_head(sequence, values):

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -55,7 +55,7 @@ def get_unstructured_solver():
     return UnstructuredSolver(client=None, data=data)
 
 
-class TestQPCoders(unittest.TestCase):
+class CodersTestBase(unittest.TestCase):
     nan = float('nan')
 
     # response to a 5-qubit problem from a 5 qubit machine
@@ -80,6 +80,9 @@ class TestQPCoders(unittest.TestCase):
     res_energies = (-15.0,)
     res_num_occurrences = (100,)
 
+
+class TestQPCoders(CodersTestBase):
+
     def encode_doubles(self, values):
         return base64.b64encode(struct.pack('<' + ('d' * len(values)), *values)).decode('utf-8')
 
@@ -92,6 +95,21 @@ class TestQPCoders(unittest.TestCase):
         self.assertEqual(request['format'], 'qp')
         self.assertEqual(request['lin'],  self.encode_doubles([1, 1, 1, 1]))
         self.assertEqual(request['quad'], self.encode_doubles([-1, -1, -1, -1]))
+
+    def test_qp_request_encodes_offset(self):
+        """Test `offset` is stored in problem data."""
+
+        solver = get_structured_solver()
+        linear, quadratic = generate_const_ising_problem(solver, h=1, j=-1)
+
+        # default offset is zero
+        request = encode_problem_as_qp(solver, linear, quadratic)
+        self.assertEqual(request['offset'], 0)
+
+        # test explicit offset
+        offset = 2.0
+        request = encode_problem_as_qp(solver, linear, quadratic, offset)
+        self.assertEqual(request['offset'], offset)
 
     def test_qp_request_encoding_sub_qubits(self):
         """Inactive qubits should be encoded as NaNs. Inactive couplers should be omitted."""
@@ -158,6 +176,10 @@ class TestQPCoders(unittest.TestCase):
         # [-1]
         self.assertEqual(request['quad'], self.encode_doubles([-1]))
 
+
+class TestQPDecoders(CodersTestBase):
+    """Test QP decoders correctly decode response data."""
+
     def test_qp_response_decoding(self):
         res = decode_qp(copy.deepcopy(self.res_msg))
 
@@ -187,6 +209,20 @@ class TestQPCoders(unittest.TestCase):
         np.testing.assert_array_equal(res.get('solutions'), np.array(self.res_solutions))
         np.testing.assert_array_equal(res.get('energies'), np.array(self.res_energies))
         np.testing.assert_array_equal(res.get('num_occurrences'), np.array(self.res_num_occurrences))
+
+
+class TestQPDecodersWithOffset(TestQPDecoders):
+    """Test decoders correctly apply energy offset."""
+
+    res_offset = 2.0
+
+    def setUp(self):
+        self.res_msg['answer']['offset'] = self.res_offset
+        self.res_energies = [en + self.res_offset for en in self.res_energies]
+
+    def test_offset_present_in_answer(self):
+        res = decode_qp(copy.deepcopy(self.res_msg))
+        self.assertEqual(res.get('offset'), self.res_offset)
 
 
 class TestBQCoders(unittest.TestCase):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -129,12 +129,15 @@ class TestEventDispatch(unittest.TestCase):
         # sample
         lin = {0: 1}
         quad = {(0, 1): 1}
+        offset = 2
         params = dict(num_reads=100)
-        future = self.solver.sample_ising(lin, quad, **params)
+        future = self.solver.sample_ising(lin, quad, offset, **params)
 
         # test entry values
         before = memo['before_sample']
-        args = dict(type_='ising', linear=lin, quadratic=quad, params=params)
+        args = dict(type_='ising', linear=lin, quadratic=quad,
+                    offset=offset, params=params,
+                    undirected_biases=False)
         self.assertEqual(before['obj'], self.solver)
         self.assertDictEqual(before['args'], args)
 


### PR DESCRIPTION
Adds optional `offset` parameter to `Solver.sample_ising()` and `Solver.sample_qubo()`. Offset is already implicitly supported in `Solver.sample_bqm()`.

Closes #408.