### PR TITLE
Add DQM solver

### DIFF
--- a/dwave/cloud/coders.py
+++ b/dwave/cloud/coders.py
@@ -394,6 +394,6 @@ def bqm_as_file(bqm, **options):
     # test explicitly to avoid copy on cast if possible
     fileviewable = (dimod.AdjArrayBQM, dimod.AdjVectorBQM, dimod.AdjMapBQM)
     if not isinstance(bqm, fileviewable):
-        bqm = AdjVectorBQM(bqm)
+        bqm = dimod.AdjVectorBQM(bqm)
 
     return BQMFileView(bqm, **options)

--- a/dwave/cloud/coders.py
+++ b/dwave/cloud/coders.py
@@ -357,7 +357,7 @@ def decode_bq(msg):
     result['sampleset'] = dimod.SampleSet.from_serializable(answer['data'])
 
     # include problem type
-    result['problem_type'] = 'bqm'
+    result['problem_type'] = msg['type']
 
     return result
 

--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -785,7 +785,7 @@ class Future(object):
         samples = [[sample[v] for v in variables] for sample in self.samples]
 
         # infer vartype from problem type
-        # note: KeyError on unknown problem types. BQMs should be handled above.
+        # note: KeyError on unknown problem types. BQM/DQM should be handled above.
         vartype_from_problem_type = {'ising': 'SPIN', 'qubo': 'BINARY'}
         vartype = vartype_from_problem_type[self.problem_type]
 

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -488,6 +488,79 @@ class BQMSolver(BaseUnstructuredSolver):
         return self.upload_problem(bqm)
 
 
+class DQMSolver(BaseUnstructuredSolver):
+    """Class for D-Wave unstructured discrete quadratic model solvers.
+
+    This class provides a :term:`DQM` sampling
+    method and encapsulates the solver description returned from the D-Wave
+    cloud API.
+
+    Args:
+        client (:class:`~dwave.cloud.client.Client`):
+            Client that manages access to this solver.
+
+        data (`dict`):
+            Data from the server describing this solver.
+
+    Note:
+        Events are not yet dispatched from unstructured solvers.
+    """
+
+    _handled_problem_types = {"dqm"}
+    _handled_encoding_formats = {"bq"}
+
+    def _encode_problem_for_upload(self, dqm):
+        try:
+            data = dqm.to_file()
+        except Exception as e:
+            logger.debug("DQM conversion to file failed with %r, "
+                         "assuming data already encoded.", e)
+            # assume `dqm` given as file, ready for upload
+            data = dqm
+
+        logger.debug("Problem encoded for upload: %r", data)
+        return data
+
+    def sample_dqm(self, dqm, **params):
+        """Sample from the specified :term:`DQM`.
+
+        Args:
+            dqm (:class:`~dimod.DiscreteQuadraticModel`/str):
+                A discrete quadratic model, or a reference to one
+                (Problem ID returned by `.upload_dqm` method).
+
+            **params:
+                Parameters for the sampling method, solver-specific.
+
+        Returns:
+            :class:`~dwave.cloud.computation.Future`
+
+        Note:
+            To use this method, dimod package has to be installed.
+        """
+        return self.sample_problem(dqm, **params)
+
+    def upload_dqm(self, dqm):
+        """Upload the specified :term:`DQM` to SAPI, returning a Problem ID
+        that can be used to submit the DQM to this solver (i.e. call the
+        `.sample_dqm` method).
+
+        Args:
+            dqm (:class:`~dimod.DiscreteQuadraticModel`/bytes-like/file-like):
+                A discrete quadratic model given either as an in-memory
+                :class:`~dimod.DiscreteQuadraticModel` object, or as raw data
+                (encoded serialized model) in either a file-like or a bytes-like
+                object.
+
+        Returns:
+            :class:`concurrent.futures.Future`[str]:
+                Problem ID in a Future. Problem ID can be used to submit
+                problems by reference.
+
+        Note:
+            To use this method, dimod package has to be installed.
+        """
+        return self.upload_problem(dqm)
 
 
 class StructuredSolver(BaseSolver):
@@ -882,4 +955,4 @@ UnstructuredSolver = BQMSolver
 
 # list of all available solvers, ordered according to loading attempt priority
 # (more specific first)
-available_solvers = [StructuredSolver, BQMSolver]
+available_solvers = [StructuredSolver, BQMSolver, DQMSolver]

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -511,7 +511,10 @@ class DQMSolver(BaseUnstructuredSolver):
 
     def _encode_problem_for_upload(self, dqm):
         try:
-            data = dqm.to_file()
+            # note: SpooledTemporaryFile currently returned by DQM.to_file
+            # does not implement io.BaseIO interface, so we use the underlying
+            # (and internal) file-like object for now
+            data = dqm.to_file()._file
         except Exception as e:
             logger.debug("DQM conversion to file failed with %r, "
                          "assuming data already encoded.", e)

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -49,7 +49,10 @@ try:
 except ImportError:
     _numpy = False
 
-__all__ = ['Solver', 'BaseSolver', 'StructuredSolver', 'UnstructuredSolver']
+__all__ = [
+    'Solver', 'BaseSolver', 'StructuredSolver',
+    'BaseUnstructuredSolver', 'BQMSolver', 'DQMSolver', 'UnstructuredSolver',
+]
 
 logger = logging.getLogger(__name__)
 

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -285,7 +285,7 @@ class BaseUnstructuredSolver(BaseSolver):
             import dimod
         except ImportError: # pragma: no cover
             raise RuntimeError("Can't use unstructured solver without dimod. "
-                               "Re-install the library with 'bqm' support.")
+                               "Re-install the library with 'bqm'/'dqm' support.")
 
         bqm = dimod.BinaryQuadraticModel.from_ising(linear, quadratic, offset)
         return self.sample_bqm(bqm, **params)
@@ -316,7 +316,7 @@ class BaseUnstructuredSolver(BaseSolver):
             import dimod
         except ImportError: # pragma: no cover
             raise RuntimeError("Can't use unstructured solver without dimod. "
-                               "Re-install the library with 'bqm' support.")
+                               "Re-install the library with 'bqm'/'dqm' support.")
 
         bqm = dimod.BinaryQuadraticModel.from_qubo(qubo, offset)
         return self.sample_bqm(bqm, **params)
@@ -523,6 +523,14 @@ class DQMSolver(BaseUnstructuredSolver):
 
         logger.debug("Problem encoded for upload: %r", data)
         return data
+
+    def sample_bqm(self, bqm, **params):
+        from dwave.cloud.utils import bqm_to_dqm
+
+        # to sample BQM problems, we need to convert them to DQM
+        dqm = bqm_to_dqm(bqm)
+
+        return self.sample_dqm(dqm, **params)
 
     def sample_dqm(self, dqm, **params):
         """Sample from the specified :term:`DQM`.

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -669,3 +669,27 @@ class aliasdict(dict):
         new = type(self)(self)
         new.alias(self.aliases)
         return new
+
+
+def bqm_to_dqm(bqm):
+    """Represent a :class:`dimod.BQM` as a :class:`dimod.DQM`."""
+    try:
+        from dimod import DiscreteQuadraticModel
+    except ImportError: # pragma: no cover
+        raise RuntimeError(
+            "dimod package with support for DiscreteQuadraticModel required."
+            "Re-install the library with 'dqm' support.")
+
+    dqm = DiscreteQuadraticModel()
+
+    ising = bqm.spin
+
+    for v, bias in ising.linear.items():
+        dqm.add_variable(2, label=v)
+        dqm.set_linear(v, [-bias, bias])
+
+    for (u, v), bias in ising.quadratic.items():
+        biases = np.array([[bias, -bias], [-bias, bias]], dtype=np.float64)
+        dqm.set_quadratic(u, v, biases)
+
+    return dqm

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ click>=7
 plucky>=0.4.3
 
 # optional bqm support
+# note: dqm supported in dimod>0.9.6
 dimod>=0.8.15
 numpy>=1.16

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ extras_require = {
 
     # bqm support
     'bqm': ['dimod>=0.8.15', 'numpy>=1.16'],
+
+    # dqm support
+    'bqm': ['dimod>=0.9.7', 'numpy>=1.16'],
 }
 
 # Packages provided. Only include packages under the 'dwave' namespace.

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -295,12 +295,15 @@ class TestBQCoders(unittest.TestCase):
     def test_bq_response_decoding(self):
         """Answer to simple problem properly decoded."""
 
+        problem_type = 'bqm'
         ss = dimod.SampleSet.from_samples(
             ([[0, 1], [1, 0]], 'ab'), vartype='BINARY', energy=0)
 
-        msg = dict(answer=dict(format='bq', data=ss.to_serializable()))
+        msg = dict(
+            answer=dict(format='bq', data=ss.to_serializable()),
+            type=problem_type)
 
         res = decode_bq(msg)
 
-        self.assertEqual(res.get('problem_type'), 'bqm')
+        self.assertEqual(res.get('problem_type'), problem_type)
         self.assertEqual(res.get('sampleset'), ss)


### PR DESCRIPTION
- abstract `dwave.cloud.solver.UnstructuredSolver` to `.BaseUnstructuredSolver`
- alias `dwave.cloud.solver.BQMSolver` as `.UnstructuredSolver`
- add `dwave.cloud.solver.DQMSolver`, with `sample_dqm` method, as well as fallback `sample_{bqm,ising,qubo}`