### PR TITLE
Bubble up SAPI errmsg on upload

### DIFF
--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -1838,7 +1838,7 @@ class Client(object):
         # via executor initializer
         with self.create_session() as session:
             chunks = ChunkedData(problem, chunk_size=self._UPLOAD_PART_SIZE_BYTES)
-            size = len(chunks.view)
+            size = chunks.total_size
 
             if problem_id is None:
                 try:

--- a/dwave/cloud/events.py
+++ b/dwave/cloud/events.py
@@ -62,6 +62,8 @@ def add_handler(name, handler):
 def dispatch_event(name, *args, **kwargs):
     """Call the complete chain of event handlers attached to event `name`."""
 
+    logger.trace("dispatch_event(%r, *%r, **%r)", name, args, kwargs)
+
     if name not in _client_event_hooks_registry:
         raise ValueError('invalid event name')
 

--- a/dwave/cloud/upload.py
+++ b/dwave/cloud/upload.py
@@ -373,11 +373,14 @@ class ChunkedData(object):
             raise TypeError("bytes/str/IOBase-subclass data required")
 
     @property
+    def total_size(self):
+        """Total data size, in bytes."""
+        return len(self.view)
+
+    @property
     def num_chunks(self):
         """Total number of chunks."""
-
-        total_size = len(self.view)
-        return math.ceil(total_size / self.chunk_size)
+        return math.ceil(self.total_size / self.chunk_size)
 
     def __len__(self):
         return self.num_chunks

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -316,6 +316,7 @@ class TestChunkedData(unittest.TestCase):
     def verify_chunking(self, cd, chunks_expected):
         self.assertEqual(len(cd), len(chunks_expected))
         self.assertEqual(cd.num_chunks, len(chunks_expected))
+        self.assertEqual(cd.total_size, sum(map(len, chunks_expected)))
 
         chunks_iter = [c.read() for c in cd]
         chunks_explicit = []


### PR DESCRIPTION
Adds consistent response parsing on all multipart upload endpoints, so that SAPI error message is propagated as `ProblemUploadError` message.

Remaining endpoints (problems/, solvers/) are not yet consistent, as they might not return a JSON error object.

Closes #433.