### PR TITLE
Accept looser file-like for upload

### DIFF
--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -525,10 +525,7 @@ class DQMSolver(BaseUnstructuredSolver):
 
     def _encode_problem_for_upload(self, dqm):
         try:
-            # note: SpooledTemporaryFile currently returned by DQM.to_file
-            # does not implement io.BaseIO interface, so we use the underlying
-            # (and internal) file-like object for now
-            data = dqm.to_file()._file
+            data = dqm.to_file()
         except Exception as e:
             logger.debug("DQM conversion to file failed with %r, "
                          "assuming data already encoded.", e)
@@ -544,6 +541,7 @@ class DQMSolver(BaseUnstructuredSolver):
         # to sample BQM problems, we need to convert them to DQM
         dqm = bqm_to_dqm(bqm)
 
+        # TODO: convert sampleset back
         return self.sample_dqm(dqm, **params)
 
     def sample_dqm(self, dqm, **params):

--- a/dwave/cloud/upload.py
+++ b/dwave/cloud/upload.py
@@ -162,7 +162,7 @@ class GettableFile(GettableBase):
         # store file size, assuming it won't change
         self._size = fp.seek(0, os.SEEK_END)
         if self._size is None:
-            # handle python2 and non-standard file seek() impl.
+            # handle non-python3 and/or non-standard file seek() impl.
             # (like tempfile.SpooledTemporaryFile)
             # note: not thread-safe!
             self._size = fp.tell()
@@ -344,7 +344,7 @@ class ChunkedData(object):
 
     def _thread_safe_data_view(self, data):
         # convenience string handler
-        if isinstance(data, str) and not isinstance(data, bytes):
+        if isinstance(data, str):
             data = data.encode('ascii')
 
         if isinstance(data, (bytes, bytearray)):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
     'bqm': ['dimod>=0.8.15', 'numpy>=1.16'],
 
     # dqm support
-    'bqm': ['dimod>=0.9.7', 'numpy>=1.16'],
+    'dqm': ['dimod>=0.9.7', 'numpy>=1.16'],
 }
 
 # Packages provided. Only include packages under the 'dwave' namespace.

--- a/tests/test_mock_unstructured_submission.py
+++ b/tests/test_mock_unstructured_submission.py
@@ -83,64 +83,70 @@ class TestUnstructuredSolver(unittest.TestCase):
             return Present(result=mock_problem_id)
 
         # construct a functional solver by mocking client and api response data
-        with mock.patch.object(Client, 'create_session', lambda self: session):
+        with mock.patch.multiple(Client, create_session=lambda self: session,
+                                 upload_problem_encoded=mock_upload):
             with Client('endpoint', 'token') as client:
-                with mock.patch.object(BaseUnstructuredSolver, 'upload_problem', mock_upload):
-                    solver = BQMSolver(client, unstructured_solver_data())
+                solver = BQMSolver(client, unstructured_solver_data())
 
-                    # make sure this still works
-                    _ = UnstructuredSolver(client, unstructured_solver_data())
+                # make sure this still works
+                _ = UnstructuredSolver(client, unstructured_solver_data())
 
-                    # direct bqm sampling
-                    ss = dimod.ExactSolver().sample(bqm)
-                    session.post = lambda path, _: choose_reply(
-                        path, {'problems/': complete_reply(ss)})
+                # direct bqm sampling
+                ss = dimod.ExactSolver().sample(bqm)
+                session.post = lambda path, _: choose_reply(
+                    path, {'problems/': complete_reply(ss)})
 
-                    fut = solver.sample_bqm(bqm)
-                    numpy.testing.assert_array_equal(fut.sampleset, ss)
-                    numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
-                    numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
-                    numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
+                fut = solver.sample_bqm(bqm)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
+                numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
+                numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
 
-                    # submit of pre-uploaded bqm problem
-                    fut = solver.sample_bqm(mock_problem_id)
-                    numpy.testing.assert_array_equal(fut.sampleset, ss)
-                    numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
-                    numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
-                    numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
+                # submit of pre-uploaded bqm problem
+                fut = solver.sample_bqm(mock_problem_id)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
+                numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
+                numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
 
-                    # ising sampling
-                    lin, quad, _ = bqm.to_ising()
-                    ss = dimod.ExactSolver().sample_ising(lin, quad)
-                    session.post = lambda path, _: choose_reply(
-                        path, {'problems/': complete_reply(ss)})
+                # ising sampling
+                lin, quad, _ = bqm.to_ising()
+                ss = dimod.ExactSolver().sample_ising(lin, quad)
+                session.post = lambda path, _: choose_reply(
+                    path, {'problems/': complete_reply(ss)})
 
-                    fut = solver.sample_ising(lin, quad)
-                    numpy.testing.assert_array_equal(fut.sampleset, ss)
-                    numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
-                    numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
-                    numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
+                fut = solver.sample_ising(lin, quad)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
+                numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
+                numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
 
-                    # qubo sampling
-                    qubo, _ = bqm.to_qubo()
-                    ss = dimod.ExactSolver().sample_qubo(qubo)
-                    session.post = lambda path, _: choose_reply(
-                        path, {'problems/': complete_reply(ss)})
+                # qubo sampling
+                qubo, _ = bqm.to_qubo()
+                ss = dimod.ExactSolver().sample_qubo(qubo)
+                session.post = lambda path, _: choose_reply(
+                    path, {'problems/': complete_reply(ss)})
 
-                    fut = solver.sample_qubo(qubo)
-                    numpy.testing.assert_array_equal(fut.sampleset, ss)
-                    numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
-                    numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
-                    numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
+                fut = solver.sample_qubo(qubo)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
+                numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
+                numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
 
     def test_sample_dqm_smoke_test(self):
         """Construction of and sampling from an unstructured DQM solver works."""
-        # note: full test pending dimod release that supports DQM
 
-        # mock a DQM problem
-        #bqm = dimod.BQM.from_ising({}, {'ab': 1})
-        dqm = mock.Mock()
-        dqm.to_file.return_value._file = io.BytesIO(b'123')
+        try:
+            import dimod
+            dqm = dimod.DQM()
+            dqm.add_variable(5)
+            dqm.add_variable(7)
+            dqm.set_linear_case(0, 3, 1.5)
+            dqm.set_quadratic(0, 1, {(0, 1): 1.5, (3, 4): 1})
+        except:
+            # dimod or dimod with DQM support not available, so just use a mock
+            dqm = mock.Mock()
+            dqm.to_file.return_value = io.BytesIO(b'123')
 
         problem_type = 'dqm'
 
@@ -153,20 +159,20 @@ class TestUnstructuredSolver(unittest.TestCase):
             return Present(result=mock_problem_id)
 
         # construct a functional solver by mocking client and api response data
-        with mock.patch.object(Client, 'create_session', lambda self: session):
+        with mock.patch.multiple(Client, create_session=lambda self: session,
+                                 upload_problem_encoded=mock_upload):
             with Client('endpoint', 'token') as client:
-                with mock.patch.object(BaseUnstructuredSolver, 'upload_problem', mock_upload):
-                    solver = DQMSolver(client, unstructured_solver_data(problem_type=problem_type))
+                solver = DQMSolver(client, unstructured_solver_data(problem_type=problem_type))
 
-                    # use bqm for now
-                    ss = dimod.ExactSolver().sample(dimod.BQM.empty('SPIN'))
-                    session.post = lambda path, _: choose_reply(
-                        path, {'problems/': complete_reply(ss, problem_type=problem_type)})
+                # use bqm for mock response (for now)
+                ss = dimod.ExactSolver().sample(dimod.BQM.empty('SPIN'))
+                session.post = lambda path, _: choose_reply(
+                    path, {'problems/': complete_reply(ss, problem_type=problem_type)})
 
-                    # verify decoding works
-                    fut = solver.sample_dqm(dqm)
-                    numpy.testing.assert_array_equal(fut.sampleset, ss)
-                    numpy.testing.assert_array_equal(fut.problem_type, problem_type)
+                # verify decoding works
+                fut = solver.sample_dqm(dqm)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.problem_type, problem_type)
 
     def test_upload_failure(self):
         """Submit should gracefully fail if upload as part of submit fails."""


### PR DESCRIPTION
We now use `DQM.to_file()`, instead of relying on the internal `_file` attribute.

Obsoletes https://github.com/dwavesystems/dimod/issues/730.