### PR TITLE
Deprecate `Future.{eta_min,eta_max}`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
 
       - save_cache: &save-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-<< parameters.xcode >>
+          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-<< parameters.xcode >>
           paths:
             - ~/.pyenv
 

--- a/dwave/cloud/client.py
+++ b/dwave/cloud/client.py
@@ -1297,12 +1297,6 @@ class Client(object):
             if not future.time_solved and message.get('solved_on'):
                 future.time_solved = parse_datetime(message['solved_on'])
 
-            if not future.eta_min and message.get('earliest_estimated_completion'):
-                future.eta_min = parse_datetime(message['earliest_estimated_completion'])
-
-            if not future.eta_max and message.get('latest_estimated_completion'):
-                future.eta_max = parse_datetime(message['latest_estimated_completion'])
-
             if status == self.STATUS_COMPLETE:
                 # TODO: find a better way to differentiate between
                 # `completed-on-submit` and `completed-on-poll`.

--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -132,11 +132,11 @@ class Future(object):
         #: `datetime` the Future was resolved (marked as done; succeeded or failed), or None before then
         self.time_resolved = None
 
-        # estimated `earliest_completion_time` as returned on problem submit
-        self.eta_min = None
+        # [removed from SAPI] estimated `earliest_completion_time` as returned on problem submit
+        self._eta_min = None
 
-        # estimated `latest_completion_time` as returned on problem submit
-        self.eta_max = None
+        # [removed from SAPI] estimated `latest_completion_time` as returned on problem submit
+        self._eta_max = None
 
         # Track how long it took us to parse the data
         self.parse_time = None
@@ -177,6 +177,36 @@ class Future(object):
             DeprecationWarning)
 
         return self._exception
+
+    # TODO: remove in 0.10.0
+    @property
+    def eta_min(self):
+        warnings.warn(
+            "'Future.eta_min' is deprecated, since the underlying "
+            "'earliest_estimated_completion' field has been removed from SAPI. "
+            "The eta_min attribute will be removed in 0.10.0.",
+            DeprecationWarning)
+
+        return self._eta_min
+
+    @eta_min.setter
+    def eta_min(self, value):
+        self._eta_min = value
+
+    # TODO: remove in 0.10.0
+    @property
+    def eta_max(self):
+        warnings.warn(
+            "'Future.eta_max' is deprecated, since the underlying "
+            "'latest_estimated_completion' field has been removed from SAPI. "
+            "The eta_max attribute will be removed in 0.10.0.",
+            DeprecationWarning)
+
+        return self._eta_max
+
+    @eta_max.setter
+    def eta_max(self, value):
+        self._eta_max = value
 
     # make Future ordered
 
@@ -230,8 +260,6 @@ class Future(object):
     def _set_clock_diff(self, server_response, localtime_of_response):
         """Calculate and set the `.clock_diff`, based on headers from a server
         response, and the local time of response received.
-
-        Based on `clock_diff`, `eta_min`/`eta_max` may or may not make sense.
         """
         try:
             server_time = datetime_to_timestamp(parse(server_response.headers['date']))

--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -132,12 +132,6 @@ class Future(object):
         #: `datetime` the Future was resolved (marked as done; succeeded or failed), or None before then
         self.time_resolved = None
 
-        # [removed from SAPI] estimated `earliest_completion_time` as returned on problem submit
-        self._eta_min = None
-
-        # [removed from SAPI] estimated `latest_completion_time` as returned on problem submit
-        self._eta_max = None
-
         # Track how long it took us to parse the data
         self.parse_time = None
 
@@ -187,11 +181,7 @@ class Future(object):
             "The eta_min attribute will be removed in 0.10.0.",
             DeprecationWarning)
 
-        return self._eta_min
-
-    @eta_min.setter
-    def eta_min(self, value):
-        self._eta_min = value
+        return None
 
     # TODO: remove in 0.10.0
     @property
@@ -202,11 +192,7 @@ class Future(object):
             "The eta_max attribute will be removed in 0.10.0.",
             DeprecationWarning)
 
-        return self._eta_max
-
-    @eta_max.setter
-    def eta_max(self, value):
-        self._eta_max = value
+        return None
 
     # make Future ordered
 


### PR DESCRIPTION
The underlying feature has already been removed from SAPI, but let's
provide a grace period for Ocean users. Although the return value has
been `None` for a while now.