### PR TITLE
Update cookie methods in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,8 +85,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ['_static']
 
 def setup(app):
-    app.add_stylesheet('cookie_notice.css')
-    app.add_javascript('cookie_notice.js')
+    app.add_css_file('cookie_notice.css')
+    app.add_js_file('cookie_notice.js')
     app.add_config_value('target', 'repo', 'env')
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx>=4.0.0,<5.0.0
 sphinx_rtd_theme


### PR DESCRIPTION
`app.add_stylesheet()` and `app.add_javascript()` were renamed in version 1.8 and obsoleted in version 4