### PR TITLE
Don't install requests with the use_chardet_on_py3 extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests[socks, use_chardet_on_py3]>=2.18
+requests[socks]>=2.18
 homebase>=1.0.0
 python-dateutil>=2.7
 click>=7

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except SyntaxError:
 python_requires = '>=3.6'
 
 # Package requirements, minimal pinning
-install_requires = ['requests[socks, use_chardet_on_py3]>=2.18',
+install_requires = ['requests[socks]>=2.18',
                     'homebase>=1.0',
                     'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3']
 


### PR DESCRIPTION
This extra seems no longer to exist.  I receive
```
WARNING: requests 2.25.1 does not provide the extra 'use_chardet_on_py3'
```
and later
```
Traceback (most recent call last):
  File "/home/pakin/.anaconda3/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2739, in requires
    deps.extend(dm[safe_extra(ext)])
KeyError: 'use_chardet_on_py3'
```
As a result, I was unable to use, in particular, the D-Wave Problem Inspector.