### PR TITLE
Simplify config create

### DIFF
--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -88,7 +88,7 @@ CONFIG_FILE_DEPRECATION_MSG = (
 def config_file_options(exists=True):
     """Decorate `fn` with `--config-file` and `--profile` options.
 
-    Optionally skip existency check by click with `exist=False`.
+    Optionally skip existency check by click with `exists=False`.
     """
 
     def decorator(fn):
@@ -185,7 +185,7 @@ def inspect(config_file, profile):
 @config.command()
 @config_file_options(exists=False)
 @click.option('--full', 'ask_full', is_flag=True,
-              help='Configure non-essential options (like endpoint and solver).')
+              help='Configure non-essential options (such as endpoint and solver).')
 def create(config_file, profile, ask_full):
     """Create or update cloud client configuration file."""
 
@@ -795,4 +795,4 @@ def setup(install_all, verbose):
             _install_contrib_package(pkg, verbose=verbose, prompt=not install_all)
 
     click.echo("Creating the D-Wave configuration file.")
-    return _config_create(config_file=None, profile=None)
+    return _config_create(config_file=None, profile=None, ask_full=False)

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -85,23 +85,28 @@ CONFIG_FILE_DEPRECATION_MSG = (
     "in favor of '-f' and it will be removed in 0.10.0")
 
 
-def config_file_options(fn):
-    """Decorate `fn` with `--config-file` and `--profile` options."""
+def config_file_options(exists=True):
+    """Decorate `fn` with `--config-file` and `--profile` options.
 
-    fn = click.option(
-        '--config-file', '-f', default=None, is_eager=True,
-        type=click.Path(exists=True, dir_okay=False),
-        help='Configuration file path')(fn)
-    fn = click.option(
-        '-c', default=None, expose_value=False,
-        type=click.Path(exists=True, dir_okay=False),
-        help="[Deprecated in favor of '-f']",
-        callback=deprecated_option(CONFIG_FILE_DEPRECATION_MSG, update='config_file'))(fn)
-    fn = click.option(
-        '--profile', '-p', default=None,
-        help='Connection profile (section) name')(fn)
+    Optionally skip existency check by click with `exist=False`.
+    """
 
-    return fn
+    def decorator(fn):
+        fn = click.option(
+            '--config-file', '-f', default=None, is_eager=True,
+            type=click.Path(exists=exists, dir_okay=False),
+            help='Configuration file path')(fn)
+        fn = click.option(
+            '-c', default=None, expose_value=False,
+            type=click.Path(exists=exists, dir_okay=False),
+            help="[Deprecated in favor of '-f']",
+            callback=deprecated_option(CONFIG_FILE_DEPRECATION_MSG, update='config_file'))(fn)
+        fn = click.option(
+            '--profile', '-p', default=None,
+            help='Connection profile (section) name')(fn)
+        return fn
+
+    return decorator
 
 
 def solver_options(fn):
@@ -159,7 +164,7 @@ def ls(system, user, local, include_missing):
 
 
 @config.command()
-@config_file_options
+@config_file_options()
 def inspect(config_file, profile):
     """Inspect existing configuration/profile."""
 
@@ -178,7 +183,7 @@ def inspect(config_file, profile):
 
 
 @config.command()
-@config_file_options
+@config_file_options(exists=False)
 @click.option('--full', 'ask_full', is_flag=True,
               help='Configure non-essential options (like endpoint and solver).')
 def create(config_file, profile, ask_full):
@@ -383,7 +388,7 @@ def _ping(config_file, profile, client_type, solver_def, sampling_params,
 
 
 @cli.command()
-@config_file_options
+@config_file_options()
 @solver_options
 @click.option('--sampling-params', '-m', default=None, help='Sampling parameters (JSON encoded)')
 @click.option('--request-timeout', default=None, type=float,
@@ -422,7 +427,7 @@ def ping(config_file, profile, client_type, solver_def, sampling_params, json_ou
 
 
 @cli.command()
-@config_file_options
+@config_file_options()
 @solver_options
 @click.option('--list', '-l', 'list_solvers', default=False, is_flag=True,
               help='Print filtered list of solver names, one per line')
@@ -471,7 +476,7 @@ def solvers(config_file, profile, client_type, solver_def, list_solvers, list_al
 
 
 @cli.command()
-@config_file_options
+@config_file_options()
 @solver_options
 @click.option('--biases', '-h', default=None,
               help='List/dict of biases for Ising model problem formulation')
@@ -551,7 +556,7 @@ def sample(config_file, profile, client_type, solver_def, biases, couplings,
 
 
 @cli.command()
-@config_file_options
+@config_file_options()
 @solver_options
 @click.option('--problem-id', '-i', default=None,
               help='Problem ID (optional)')

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -256,7 +256,8 @@ def _config_create(config_file, profile, ask_full=False):
         if not config_file:
             config_file = get_default_configfile_path()
 
-    verb = "Updating existing" if os.path.exists(config_file) else "Creating new"
+    config_file_exists = os.path.exists(config_file)
+    verb = "Updating existing" if config_file_exists else "Creating new"
     click.echo(f"{verb} configuration file: {config_file}")
 
     if ask_full and ask_to_confirm_config_path:
@@ -269,13 +270,14 @@ def _config_create(config_file, profile, ask_full=False):
     # resolve profile
     if not profile:
         existing = config.sections()
-        if existing:
-            if default_section in config:
-                existing.insert(0, default_section)
-            click.echo(f"Found profiles: {', '.join(existing)}.")
+        if default_section in config:   # not included in sections
+            existing.insert(0, default_section)
+        if config_file_exists:
+            click.echo(f"Available profiles: {', '.join(existing)}")
         default_profile = next(iter(existing))
 
-        profile = default_text_input(f"Profile (select existing or create new)", default_profile)
+        _note = " (select existing or create new)" if config_file_exists else ""
+        profile = default_text_input(f"Profile{_note}", default_profile)
 
     verb = "Updating existing" if profile in config else "Creating new"
     click.echo(f"{verb} profile: {profile}")

--- a/releasenotes/notes/simplify-config-create-897b75bc64ef5c2a.yaml
+++ b/releasenotes/notes/simplify-config-create-897b75bc64ef5c2a.yaml
@@ -1,0 +1,22 @@
+---
+features:
+  - |
+    Default ``dwave config create`` configuration flow is now simplified to
+    prompt only for essential parameters (at the moment that's only ``token``).
+
+    Interactive configuration of an extended set of non-essential parameters
+    (i.e. the previous default) is now available via a new flag: ``--full``.
+
+    See `#304 <https://github.com/dwavesystems/dwave-cloud-client/issues/304>`_
+fixes:
+  - |
+    When a path to a nonexistent config file is provided to
+    ``dwave config create``, we'll now happily create that file, instead of
+    failing.
+upgrade:
+  - |
+    To configure non-essential parameters such as ``endpoint``, ``client``
+    and ``solver``, configuration create command now has to be called with
+    the ``--full`` option::
+
+      dwave config create --full

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,20 +35,18 @@ def touch(path):
         os.utime(path, None)
 
 
-class TestCli(unittest.TestCase):
+class TestConfigCreate(unittest.TestCase):
 
     @parameterized.expand([
         ("simple", [], ["token"]),
         ("full", ["--full"], "endpoint token client solver".split()),
     ])
-    def test_config_create(self, name, extra_opts, inputs):
-        config_file = 'dwave.conf'
+    def test_create(self, name, extra_opts, inputs):
+        config_file = 'path/to/dwave.conf'
         profile = 'profile'
 
         runner = CliRunner(mix_stderr=False)
         with runner.isolated_filesystem():
-            # create config file through simulated user input in `dwave configure`
-            touch(config_file)
             with mock.patch("dwave.cloud.utils.input", side_effect=inputs):
                 result = runner.invoke(cli, [
                     'config', 'create', '--config-file', config_file, '--profile', profile

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,64 @@ class TestConfigCreate(unittest.TestCase):
                 for val in inputs:
                     self.assertEqual(config.get(val), val)
 
+    @parameterized.expand([
+        ("simple", [], ["", "token"]),
+        ("full", ["--full"], ["", ""] + "endpoint token client solver".split()),
+    ])
+    def test_default_flows(self, name, extra_opts, inputs):
+        runner = CliRunner(mix_stderr=False)
+        with runner.isolated_filesystem():
+            with mock.patch("dwave.cloud.config.get_configfile_paths", lambda: ['dwave.conf']):
+                with mock.patch("dwave.cloud.utils.input", side_effect=inputs):
+                    result = runner.invoke(cli, [
+                        'config', 'create'
+                    ] + extra_opts, input='\n'.join(inputs))
+                    self.assertEqual(result.exit_code, 0)
+
+                # load and verify config
+                with isolated_environ(remove_dwave=True):
+                    config = load_config()
+                    for val in inputs:
+                        if val:   # skip empty default confirmations
+                            self.assertEqual(config.get(val), val)
+
+    @parameterized.expand([
+        ("simple", [], ["token"]),
+        ("full", ["--full"], "endpoint token client solver".split()),
+    ])
+    def test_update(self, name, extra_opts, inputs):
+        config_file = 'dwave.conf'
+        profile = 'profile'
+
+        runner = CliRunner(mix_stderr=False)
+        with runner.isolated_filesystem():
+            # create config
+            config_body = '\n'.join(f"{v} = old-{v}" for v in inputs)
+            with open(config_file, 'w') as fp:
+                fp.write(f"[{profile}]\n{config_body}")
+
+            # verify config before update
+            with isolated_environ(remove_dwave=True):
+                config = load_config(config_file=config_file)
+                for val in inputs:
+                    self.assertEqual(config.get(val), f"old-{val}")
+
+            # update config
+            with mock.patch("dwave.cloud.utils.input", side_effect=inputs):
+                result = runner.invoke(cli, [
+                    'config', 'create', '-f', config_file, '-p', profile,
+                ] + extra_opts, input='\n'.join(inputs))
+                self.assertEqual(result.exit_code, 0)
+
+            # verify config updated
+            with isolated_environ(remove_dwave=True):
+                config = load_config(config_file=config_file)
+                for val in inputs:
+                    self.assertEqual(config.get(val), val)
+
+
+class TestCli(unittest.TestCase):
+
     def test_config_ls(self):
         runner = CliRunner(mix_stderr=False)
         with runner.isolated_filesystem():


### PR DESCRIPTION
### New default (minimal config flow)
```
$ dwave config create
Using the simplified configuration flow.
Try 'dwave config create --full' for more options.

Creating new configuration file: /home/user/.config/dwave/dwave.conf
Profile [defaults]: ⏎
Updating existing profile: defaults
Authentication token [skip]: TOK-en⏎
Configuration saved.
```

```
$ cat /home/user/.config/dwave/dwave.conf
[defaults]
token = TOK-en
```

### "Full" config (old behavior)
```
$ dwave config create --full
Updating existing configuration file: /home/user/.config/dwave/dwave.conf
Confirm configuration file path [/home/user/.config/dwave/dwave.conf]: ⏎
Available profiles: defaults
Profile (select existing or create new) [defaults]: prod⏎
Creating new profile: prod
Solver API endpoint URL [skip]: https://endpoint.com⏎
Authentication token [TOK-en]: DEV-xx⏎
Client class [skip]: ⏎
Solver [skip]: {"num_active_qubits__gt": 4000}⏎
Configuration saved.
```
```
$ cat /home/user/.config/dwave/dwave.conf
[defaults]
token = TOK-en

[prod]
endpoint = https://endpoint.com
token = DEV-xx
solver = {"num_active_qubits__gt": 4000}
```


Close #304.