### PR TITLE
Improve check_problem

### DIFF
--- a/dwave/cloud/exceptions.py
+++ b/dwave/cloud/exceptions.py
@@ -82,6 +82,9 @@ class InvalidAPIResponseError(api.ResourceBadResponseError):
 class InvalidProblemError(ValueError):
     """Solver cannot handle the given binary quadratic model."""
 
+class ProblemStructureError(InvalidProblemError):   # inherit for backwards compat
+    """Problem structure incompatible with a structured solver graph."""
+
 
 class ProblemUploadError(Exception):
     """Problem multipart upload failed."""

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -31,7 +31,8 @@ You can list all solvers available to a :class:`~dwave.cloud.client.Client` with
 import json
 import logging
 import warnings
-from collections import abc
+from collections.abc import Iterable, Mapping
+from typing import Tuple
 
 from dwave.cloud.exceptions import *
 from dwave.cloud.coders import (
@@ -955,7 +956,7 @@ class StructuredSolver(BaseSolver):
             # that they match because lin can be either a list or a dict. In the future it would be
             # good to check.
             initial_state = params['initial_state']
-            if isinstance(initial_state, abc.Mapping):
+            if isinstance(initial_state, Mapping):
 
                 initial_state_list = [3]*self.properties['num_qubits']
 
@@ -983,7 +984,7 @@ class StructuredSolver(BaseSolver):
                 Quadratic terms of the model (J).
 
         Returns:
-            boolean
+            bool
 
         Examples:
             This example creates a client using the local system's default D-Wave Cloud Client
@@ -1005,13 +1006,11 @@ class StructuredSolver(BaseSolver):
             False
             True
         """
-        for key, value in uniform_iterator(linear):
-            if value != 0 and key not in self.nodes:
-                return False
-        for key, value in uniform_iterator(quadratic):
-            if value != 0 and tuple(key) not in self.edges:
-                return False
-        return True
+        # handle legacy format
+        if not isinstance(linear, Mapping):
+             linear = {idx: val for idx, val in enumerate(linear) if val != 0}
+
+        return self.nodes.issuperset(linear) and self.edges.issuperset(quadratic)
 
 
 # for backwards compatibility:

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -31,10 +31,11 @@ You can list all solvers available to a :class:`~dwave.cloud.client.Client` with
 import json
 import logging
 import warnings
-from collections.abc import Iterable, Mapping
-from typing import Tuple
+from collections.abc import Mapping
 
-from dwave.cloud.exceptions import *
+from dwave.cloud.exceptions import (
+    InvalidAPIResponseError, SolverPropertyMissingError,
+    UnsupportedSolverError, ProblemStructureError)
 from dwave.cloud.coders import (
     encode_problem_as_qp, encode_problem_as_ref,
     decode_qp_numpy, decode_qp, decode_bq, bqm_as_file)
@@ -911,7 +912,8 @@ class StructuredSolver(BaseSolver):
 
         # Check the problem
         if not self.check_problem(linear, quadratic):
-            raise InvalidProblemError("Problem graph incompatible with solver.")
+            raise ProblemStructureError(
+                f"Problem graph incompatible with {self.id} solver")
 
         # Mix the new parameters with the default parameters
         combined_params = dict(self._params)

--- a/releasenotes/notes/speedup-solver-53bf76a696e68630.yaml
+++ b/releasenotes/notes/speedup-solver-53bf76a696e68630.yaml
@@ -3,3 +3,7 @@ fixes:
   - |
     Make ``StructuredSolver.check_problem`` faster (15-20%).
     See `#487 <https://github.com/dwavesystems/dwave-cloud-client/issues/487>`_.
+upgrade:
+  - |
+    Sampling on structured solvers of problems with incompatible graph/structure
+    now fails with ``ProblemStructureError``.

--- a/releasenotes/notes/speedup-solver-53bf76a696e68630.yaml
+++ b/releasenotes/notes/speedup-solver-53bf76a696e68630.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Make ``StructuredSolver.check_problem`` faster (15-20%).
+    See `#487 <https://github.com/dwavesystems/dwave-cloud-client/issues/487>`_.

--- a/tests/test_solver_utils.py
+++ b/tests/test_solver_utils.py
@@ -37,7 +37,8 @@ P16 = StructuredSolver(data=mocks.qpu_pegasus_solver_data(16), client=None)
 class TestCheckProblem(unittest.TestCase):
 
     def test_identity(self):
-        bqm = dimod.generators.ran_r(1, (self.solver.nodes, self.solver.edges))
+        # NOTE: cast to list can be removed once we drop support for dimod 0.8.x
+        bqm = dimod.generators.ran_r(1, list(self.solver.edges))
         self.assertTrue(self.solver.check_problem(bqm.linear, bqm.quadratic))
 
     def test_valid_subgraph(self):
@@ -54,11 +55,12 @@ class TestCheckProblem(unittest.TestCase):
 
     def test_supergraph(self):
         n = max(self.solver.nodes)
-        edges = list(self.solver.edges) + [(n+i, n+2*i) for i in range(10)]
+        edges = list(self.solver.edges) + [(n+i, n+2*i) for i in range(1, 10)]
         bqm = dimod.generators.ran_r(1, edges)
         self.assertFalse(self.solver.check_problem(bqm.linear, bqm.quadratic))
 
     def test_legacy_format(self):
-        bqm = dimod.generators.ran_r(1, (self.solver.nodes, self.solver.edges))
+        # NOTE: cast to list can be removed once we drop support for dimod 0.8.x
+        bqm = dimod.generators.ran_r(1, list(self.solver.edges))
         h = list(bqm.linear.values())   # h as list is still supported
         self.assertTrue(self.solver.check_problem(h, bqm.quadratic))

--- a/tests/test_solver_utils.py
+++ b/tests/test_solver_utils.py
@@ -1,0 +1,64 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import networkx as nx
+from parameterized import parameterized_class
+
+try:
+    import dimod
+except ImportError:
+    raise unittest.SkipTest("dimod not installed")
+
+from dwave.cloud.solver import StructuredSolver
+from dwave.cloud.testing import mocks
+
+
+C16 = StructuredSolver(data=mocks.qpu_chimera_solver_data(16), client=None)
+P16 = StructuredSolver(data=mocks.qpu_pegasus_solver_data(16), client=None)
+
+
+@parameterized_class(("solver", ), [
+    (C16, ),
+    (P16, ),
+])
+class TestCheckProblem(unittest.TestCase):
+
+    def test_identity(self):
+        bqm = dimod.generators.ran_r(1, (self.solver.nodes, self.solver.edges))
+        self.assertTrue(self.solver.check_problem(bqm.linear, bqm.quadratic))
+
+    def test_valid_subgraph(self):
+        bqm = dimod.generators.ran_r(1, list(self.solver.edges)[:10])
+        self.assertTrue(self.solver.check_problem(bqm.linear, bqm.quadratic))
+
+    def test_invalid_subgraph(self):
+        bqm = dimod.generators.ran_r(1, 10)
+        self.assertFalse(self.solver.check_problem(bqm.linear, bqm.quadratic))
+
+    def test_invalid_small(self):
+        bqm = dimod.BQM.from_ising({}, {'ab': 1, 'bc': 1, 'ca': 1})
+        self.assertFalse(self.solver.check_problem(bqm.linear, bqm.quadratic))
+
+    def test_supergraph(self):
+        n = max(self.solver.nodes)
+        edges = list(self.solver.edges) + [(n+i, n+2*i) for i in range(10)]
+        bqm = dimod.generators.ran_r(1, edges)
+        self.assertFalse(self.solver.check_problem(bqm.linear, bqm.quadratic))
+
+    def test_legacy_format(self):
+        bqm = dimod.generators.ran_r(1, (self.solver.nodes, self.solver.edges))
+        h = list(bqm.linear.values())   # h as list is still supported
+        self.assertTrue(self.solver.check_problem(h, bqm.quadratic))


### PR DESCRIPTION
Implements 15-20% speed-up of `StructuredSolver.check_problem()` and a new exception that `DWaveSampler` can use to skip (the duplicated) problem check.

Close #487.