### PR TITLE
Add license file to distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     long_description=open('README.rst', encoding='utf-8').read(),
     url=package_info['__url__'],
     license=package_info['__license__'],
+    license_files=["LICENSE"],
     packages=packages,
     python_requires=python_requires,
     install_requires=install_requires,


### PR DESCRIPTION
Currently, the license file is not included in the PyPI distribution. This should fix it.

Ref: https://pypi.org/project/dwave-cloud-client/#files

CC https://github.com/dwavesystems/dwave-ocean-sdk/issues/144