### PR TITLE
Ensure `Future.wait*()` calls complete on SAPI errors

### DIFF
--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -230,6 +230,7 @@ class Future(object):
     def _signal_ready(self):
         """Signal all the events waiting on this future."""
         self.time_resolved = utcnow()
+        self._id_ready_event.set()
         self._results_ready_event.set()
         [ev.set() for ev in self._other_events]
 

--- a/releasenotes/notes/fix-wait_id-30686246e3002406.yaml
+++ b/releasenotes/notes/fix-wait_id-30686246e3002406.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Make sure `Future.wait_id()` fails deterministically in a case of problem
+    submit error. Previously it would hang if SAPI didn't return problem_id for
+    whatever reason.
+    See `#469 <https://github.com/dwavesystems/dwave-cloud-client/issues/469>`_
+    and `#511 <https://github.com/dwavesystems/dwave-cloud-client/issues/511>`_.

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -302,6 +302,11 @@ class MockSubmission(_QueryTest):
                 linear, quadratic = self.sapi.problem
                 results = solver.sample_ising(linear, quadratic)
 
+                # waiting should be canceled on exception (i.e. NOT timeout)
+                self.assertTrue(results.wait(timeout=1))
+                self.assertIsNone(results.wait_id(timeout=1))
+
+                # resolving result should raise exception
                 with self.assertRaises(SolverFailureError):
                     results.samples
 


### PR DESCRIPTION
Fix #469.
Fix #511.