### PR TITLE
Add `poll_backoff_base` and make polling backoff less aggressive

### DIFF
--- a/releasenotes/notes/add-polling-base-param-f164cb37a8b9a445.yaml
+++ b/releasenotes/notes/add-polling-base-param-f164cb37a8b9a445.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Add ``poll_backoff_base`` configuration option to control the exponential
+    base of the (problem status) polling schedule. Available as a config file
+    option and ``dwave.cloud.Client`` keyword argument.
+upgrade:
+  - |
+    Make polling schedule denser in the beginning (by lowering the exponential
+    base from ``2`` to ``1.3``), thus enabling much faster answer download for
+    SAPI response times under two minutes.

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -515,7 +515,9 @@ class MockSubmission(_QueryTest):
                 future.result()
 
                 # after third poll, back-off interval should be 4 x initial back-off
-                self.assertEqual(future._poll_backoff, client.poll_backoff_min * 2**2)
+                self.assertAlmostEqual(
+                    future._poll_backoff,
+                    client.poll_backoff_min * client.poll_backoff_base**2)
 
     def test_immediate_polling(self):
         "First poll happens with minimal delay"
@@ -620,7 +622,9 @@ class MockSubmission(_QueryTest):
                 future.result()
 
                 # after third poll, back-off interval should be 4 x initial back-off
-                self.assertEqual(future._poll_backoff, client.poll_backoff_min * 2**2)
+                self.assertAlmostEqual(
+                    future._poll_backoff,
+                    client.poll_backoff_min * client.poll_backoff_base**2)
 
 
 class DeleteEvent(Exception):


### PR DESCRIPTION
By lowering the exponential base of the backoff schedule from 2 to 1.3
we are making sampling more responsive (particularly for short response
times).