### PR TITLE
Add LeapAPI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,13 +130,10 @@ jobs:
 
   test-docs:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.9
 
     steps:
       - checkout
-
-      - restore_cache:
-          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ checksum "docs/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run: *create-virtualenv
 
@@ -145,11 +142,6 @@ jobs:
       - run:
           name: Install docs requirements
           command: env/bin/pip install -r docs/requirements.txt
-
-      - save_cache:
-          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ checksum "docs/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
-          paths:
-            - env
 
       - run: *install-package
 

--- a/dwave/cloud/api/__init__.py
+++ b/dwave/cloud/api/__init__.py
@@ -27,5 +27,5 @@ from dwave.cloud.api import exceptions
 from dwave.cloud.api import models
 from dwave.cloud.api import resources
 
-from dwave.cloud.api.client import DWaveAPIClient, SolverAPIClient, MetadataAPIClient
-from dwave.cloud.api.resources import Solvers, Problems, Regions
+from dwave.cloud.api.client import DWaveAPIClient, SolverAPIClient, MetadataAPIClient, LeapAPIClient
+from dwave.cloud.api.resources import Solvers, Problems, Regions, LeapAccount

--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -327,7 +327,7 @@ class DWaveAPIClient:
         return retry
 
     @classmethod
-    def _add_auth(cls, session, config):
+    def _set_session_auth(cls, session, config):
         if config['token']:
             session.headers.update({'X-Auth-Token': config['token']})
         if config['cert']:
@@ -363,7 +363,7 @@ class DWaveAPIClient:
             session.headers.update(config['headers'])
 
         # auth
-        cls._add_auth(session, config)
+        cls._set_session_auth(session, config)
 
         if config['proxies']:
             session.proxies = config['proxies']
@@ -489,7 +489,7 @@ class LeapAPIClient(DWaveAPIClient):
     """Client for D-Wave's Leap API."""
 
     @classmethod
-    def _add_auth(cls, session, config):
+    def _set_session_auth(cls, session, config):
         if config['token']:
             session.headers.update({'Authorization': f"Bearer {config['token']}"})
 

--- a/dwave/cloud/api/constants.py
+++ b/dwave/cloud/api/constants.py
@@ -20,7 +20,7 @@ DEFAULT_SOLVER_API_ENDPOINT = 'https://cloud.dwavesys.com/sapi/'
 
 DEFAULT_METADATA_API_ENDPOINT = 'https://cloud.dwavesys.com/metadata/v1/'
 
-DEFAULT_LEAP_API_ENDPOINT = 'https://cloud.dwavesys.com/leap/'
+DEFAULT_LEAP_API_ENDPOINT = 'https://cloud.dwavesys.com/leap/api/'
 
 DEFAULT_REGION = 'na-west-1'
 

--- a/dwave/cloud/api/constants.py
+++ b/dwave/cloud/api/constants.py
@@ -20,6 +20,8 @@ DEFAULT_SOLVER_API_ENDPOINT = 'https://cloud.dwavesys.com/sapi/'
 
 DEFAULT_METADATA_API_ENDPOINT = 'https://cloud.dwavesys.com/metadata/v1/'
 
+DEFAULT_LEAP_API_ENDPOINT = 'https://cloud.dwavesys.com/leap/'
+
 DEFAULT_REGION = 'na-west-1'
 
 

--- a/dwave/cloud/api/models.py
+++ b/dwave/cloud/api/models.py
@@ -150,3 +150,32 @@ class Region(BaseModel):
     code: str
     name: str
     endpoint: str
+
+
+# LeapAPI types, provisional
+
+class LeapProject(BaseModel):
+    id: int
+    name: str
+    code: str
+
+class _LeapProjectWrapper(BaseModel):
+    project: LeapProject
+
+# LeapAPI / account / active project response
+class _LeapActiveProjectResponse(BaseModel):
+    data: _LeapProjectWrapper
+
+# LeapAPI / account / projects response
+class _LeapProjectsWrapper(BaseModel):
+    projects: List[_LeapProjectWrapper]
+
+class _LeapProjectsResponse(BaseModel):
+    data: _LeapProjectsWrapper
+
+# LeapAPI / account / token response
+class _LeapTokenWrapper(BaseModel):
+    token: str
+
+class _LeapProjectTokenResponse(BaseModel):
+    data: _LeapTokenWrapper

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -280,7 +280,7 @@ class Problems(ResourceBase):
 
 class LeapAccount(ResourceBase):
 
-    resource_path = 'api/account/'
+    resource_path = 'account/'
     client_class = LeapAPIClient
 
     # TODO: constrain accepted resource/response version, when

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -18,7 +18,8 @@ from functools import wraps
 
 from pydantic import parse_obj_as
 
-from dwave.cloud.api.client import DWaveAPIClient, SolverAPIClient, MetadataAPIClient
+from dwave.cloud.api.client import (
+    DWaveAPIClient, SolverAPIClient, MetadataAPIClient, LeapAPIClient)
 from dwave.cloud.api import constants, models
 from dwave.cloud.utils import NumpyEncoder
 
@@ -275,3 +276,41 @@ class Problems(ResourceBase):
         response = self.session.delete(path, json=problem_ids)
         rtype = get_type_hints(self.cancel_problems)['return']
         return parse_obj_as(rtype, response.json())
+
+
+class LeapAccount(ResourceBase):
+
+    resource_path = 'api/account/'
+
+    def __init__(self, **config):
+        self.client = LeapAPIClient(**config)
+        self.session = self.client.session
+        self._patch_session()
+
+    def get_active_project(self) -> models.LeapProject:
+        """Retrieve user's active Leap project, as selected in Leap dashboard."""
+        path = 'active_project/oauth/'
+        response = self.session.get(path)
+        parsed = models._LeapActiveProjectResponse.parse_obj(response.json())
+        return parsed.data.project
+
+    def get_projects(self) -> List[models.LeapProject]:
+        """Retrieve list of Leap projects accessible to the authenticated user."""
+        path = 'projects/oauth/'
+        response = self.session.get(path)
+        parsed = models._LeapProjectsResponse.parse_obj(response.json())
+        return [p.project for p in parsed.data.projects]
+
+    def get_project_token(self, *,
+                          project: Optional[models.LeapProject] = None,
+                          project_id: Optional[str] = None) -> str:
+        """Retrieve SAPI token for a given Leap project."""
+        if project is not None:
+            project_id = project.id
+        if project_id is None:
+            raise ValueError("'project' or 'project_id' must be given.")
+        path = 'token/oauth/'
+        query = {'project_id': project_id}
+        response = self.session.get(path, params=query)
+        parsed = models._LeapProjectTokenResponse.parse_obj(response.json())
+        return parsed.data.token

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -281,12 +281,10 @@ class Problems(ResourceBase):
 class LeapAccount(ResourceBase):
 
     resource_path = 'api/account/'
+    client_class = LeapAPIClient
 
-    def __init__(self, **config):
-        self.client = LeapAPIClient(**config)
-        self.session = self.client.session
-        self._patch_session()
-
+    # TODO: constrain accepted resource/response version, when
+    # media type defined for Leap API responses
     def get_active_project(self) -> models.LeapProject:
         """Retrieve user's active Leap project, as selected in Leap dashboard."""
         path = 'active_project/oauth/'
@@ -294,7 +292,7 @@ class LeapAccount(ResourceBase):
         parsed = models._LeapActiveProjectResponse.parse_obj(response.json())
         return parsed.data.project
 
-    def get_projects(self) -> List[models.LeapProject]:
+    def list_projects(self) -> List[models.LeapProject]:
         """Retrieve list of Leap projects accessible to the authenticated user."""
         path = 'projects/oauth/'
         response = self.session.get(path)

--- a/releasenotes/notes/add-leap-api-support-b87f94e77b1b2866.yaml
+++ b/releasenotes/notes/add-leap-api-support-b87f94e77b1b2866.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add basic support for Leap API access with ``dwave.cloud.api.client.LeapAPIClient``
+    and ``dwave.cloud.api.resources.LeapAccount``.

--- a/tests/api/resources/test_account.py
+++ b/tests/api/resources/test_account.py
@@ -1,0 +1,133 @@
+# Copyright 2022 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+import unittest
+from urllib.parse import urljoin
+from dwave.cloud.api.client import LeapAPIClient
+
+import requests_mock
+
+from dwave.cloud.api.resources import LeapAccount
+from dwave.cloud.api import exceptions
+
+from tests import config
+
+
+class TestMockAccount(unittest.TestCase):
+    """Test request formation and response parsing (including error handling)
+    works correctly for all :class:`dwave.cloud.api.resources.LeapAccount`
+    methods.
+    """
+
+    token = str(uuid.uuid4())
+    endpoint = 'http://test.com/path/'
+
+    def setUp(self):
+        self.mocker = requests_mock.Mocker()
+
+        self.p1 = {"id": 1, "name": "Project I", "code": "ONE"}
+        self.p2 = {"id": 2, "name": "Project II", "code": "TWO"}
+        headers = {'Authorization': f'Bearer {self.token}'}
+
+        self.mocker.get(requests_mock.ANY, status_code=401)
+        self.mocker.get(requests_mock.ANY, status_code=404, request_headers=headers)
+
+        active_project_uri = urljoin(self.endpoint, 'api/account/active_project/oauth/')
+        active_project_data = {"data": {"project": self.p1}}
+        self.mocker.get(active_project_uri, json=active_project_data, request_headers=headers)
+
+        projects_uri = urljoin(self.endpoint, 'api/account/projects/oauth/')
+        projects_data = {"data": {"projects": [{"project": self.p1}, {"project": self.p2}]}}
+        self.mocker.get(projects_uri, json=projects_data, request_headers=headers)
+
+        token_uri = urljoin(self.endpoint, 'api/account/token/oauth/')
+        self.project_token = {1: "ONE-123", 2: "TWO-234"}
+        self.mocker.get(f"{token_uri}?project_id={self.p1['id']}",
+                        json={"data": {"token": self.project_token[self.p1['id']]}},
+                        request_headers=headers)
+        self.mocker.get(f"{token_uri}?project_id={self.p2['id']}",
+                        json={"data": {"token": self.project_token[self.p2['id']]}},
+                        request_headers=headers)
+
+        self.mocker.start()
+
+    def tearDown(self):
+        self.mocker.stop()
+
+    def test_get_active_project(self):
+        """Active Leap project fetched."""
+
+        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
+        project = resource.get_active_project()
+
+        self.assertEqual(project.id, self.p1['id'])
+        self.assertEqual(project.name, self.p1['name'])
+        self.assertEqual(project.code, self.p1['code'])
+
+    def test_get_project(self):
+        """All Leap projects fetched."""
+
+        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
+        projects = resource.get_projects()
+
+        ref = [self.p1, self.p2]
+        self.assertEqual(len(projects), len(ref))
+        for i in range(len(ref)):
+            self.assertEqual(projects[i].id, ref[i]['id'])
+            self.assertEqual(projects[i].name, ref[i]['name'])
+            self.assertEqual(projects[i].code, ref[i]['code'])
+
+    def test_get_project_token(self):
+        """Correct token for Leap project fetched."""
+
+        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
+        project = resource.get_active_project()
+
+        token = resource.get_project_token(project_id=project.id)
+        self.assertEqual(token, self.project_token[project.id])
+
+        token = resource.get_project_token(project=project)
+        self.assertEqual(token, self.project_token[project.id])
+
+    def test_get_project_token__for_nonexisting_project(self):
+        """Not found error is raised when trying to fetch a non-existing
+        project's token."""
+
+        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
+        with self.assertRaises(exceptions.ResourceNotFoundError):
+            resource.get_project_token(project_id=42)
+
+    def test_invalid_token(self):
+        """Auth error is raised when request not authorized with token."""
+
+        resource = LeapAccount(token='invalid-token', endpoint=self.endpoint)
+        with self.assertRaises(exceptions.ResourceAuthenticationError):
+            resource.get_active_project()
+
+
+@unittest.skipUnless(config, "LeapAPI access not configured.")
+class TestCloudAccount(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        with LeapAPIClient(**config) as client:
+            cls.api = LeapAccount.from_client_config(client)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.api.close()
+
+    # TODO: we need to implement generalized config before we can implement
+    # live tests (access_token has to be stored)

--- a/tests/api/resources/test_account.py
+++ b/tests/api/resources/test_account.py
@@ -63,24 +63,25 @@ class TestMockAccount(unittest.TestCase):
 
         self.mocker.start()
 
+        self.api = LeapAccount(token=self.token, endpoint=self.endpoint, version_strict_mode=False)
+
     def tearDown(self):
+        self.api.close()
         self.mocker.stop()
 
     def test_get_active_project(self):
         """Active Leap project fetched."""
 
-        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
-        project = resource.get_active_project()
+        project = self.api.get_active_project()
 
         self.assertEqual(project.id, self.p1['id'])
         self.assertEqual(project.name, self.p1['name'])
         self.assertEqual(project.code, self.p1['code'])
 
-    def test_get_project(self):
+    def test_list_projects(self):
         """All Leap projects fetched."""
 
-        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
-        projects = resource.get_projects()
+        projects = self.api.list_projects()
 
         ref = [self.p1, self.p2]
         self.assertEqual(len(projects), len(ref))
@@ -92,22 +93,21 @@ class TestMockAccount(unittest.TestCase):
     def test_get_project_token(self):
         """Correct token for Leap project fetched."""
 
-        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
-        project = resource.get_active_project()
+        project = self.api.get_active_project()
+        self.assertEqual(project.id, self.p1['id'])
 
-        token = resource.get_project_token(project_id=project.id)
+        token = self.api.get_project_token(project_id=project.id)
         self.assertEqual(token, self.project_token[project.id])
 
-        token = resource.get_project_token(project=project)
+        token = self.api.get_project_token(project=project)
         self.assertEqual(token, self.project_token[project.id])
 
     def test_get_project_token__for_nonexisting_project(self):
         """Not found error is raised when trying to fetch a non-existing
         project's token."""
 
-        resource = LeapAccount(token=self.token, endpoint=self.endpoint)
         with self.assertRaises(exceptions.ResourceNotFoundError):
-            resource.get_project_token(project_id=42)
+            self.api.get_project_token(project_id=42)
 
     def test_invalid_token(self):
         """Auth error is raised when request not authorized with token."""

--- a/tests/api/resources/test_account.py
+++ b/tests/api/resources/test_account.py
@@ -31,7 +31,7 @@ class TestMockAccount(unittest.TestCase):
     """
 
     token = str(uuid.uuid4())
-    endpoint = 'http://test.com/path/'
+    endpoint = 'http://test.com/path/api/'
 
     def setUp(self):
         self.mocker = requests_mock.Mocker()
@@ -43,15 +43,15 @@ class TestMockAccount(unittest.TestCase):
         self.mocker.get(requests_mock.ANY, status_code=401)
         self.mocker.get(requests_mock.ANY, status_code=404, request_headers=headers)
 
-        active_project_uri = urljoin(self.endpoint, 'api/account/active_project/oauth/')
+        active_project_uri = urljoin(self.endpoint, 'account/active_project/oauth/')
         active_project_data = {"data": {"project": self.p1}}
         self.mocker.get(active_project_uri, json=active_project_data, request_headers=headers)
 
-        projects_uri = urljoin(self.endpoint, 'api/account/projects/oauth/')
+        projects_uri = urljoin(self.endpoint, 'account/projects/oauth/')
         projects_data = {"data": {"projects": [{"project": self.p1}, {"project": self.p2}]}}
         self.mocker.get(projects_uri, json=projects_data, request_headers=headers)
 
-        token_uri = urljoin(self.endpoint, 'api/account/token/oauth/')
+        token_uri = urljoin(self.endpoint, 'account/token/oauth/')
         self.project_token = {1: "ONE-123", 2: "TWO-234"}
         self.mocker.get(f"{token_uri}?project_id={self.p1['id']}",
                         json={"data": {"token": self.project_token[self.p1['id']]}},


### PR DESCRIPTION
In this PR we add `LeapAPIClient`  base client, `LeapAccount` resource class, and the appropriate Leap API models (types) in order to support:
- fetching the active project in Leap
- listing all user projects
- fetching SAPI token for each of the available projects