### PR TITLE
Enforce API response version validation

### DIFF
--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -247,14 +247,14 @@ class DWaveAPIClient:
 
     @staticmethod
     def _raise_for_status(response, **kwargs):
-        """Raises :class:`~dwave.cloud.exceptions.SAPIRequestError`, if one
+        """Raises :class:`~dwave.cloud.api.exceptions.RequestError`, if one
         occurred, with message populated from SAPI error response.
 
         See:
             :meth:`requests.Response.raise_for_status`.
 
         Raises:
-            :class:`dwave.cloud.exceptions.SAPIRequestError` subclass
+            :class:`dwave.cloud.api.exceptions.RequestError` subclass
         """
         # NOTE: the expected behavior is for SAPI to return JSON error on
         # failure. However, that is currently not the case. We need to work

--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -178,8 +178,9 @@ class VersionedAPISession(LoggingSession):
                         f'with supported version {self._accept_version!r}. '
                         'Try upgrading "dwave-cloud-client".')
 
-    def request(self, method, url, *args, **kwargs):
-        headers = kwargs.pop('headers', {})
+    def request(self, method: str, url: str, *args, **kwargs):
+        headers = kwargs.pop('headers', None)
+        headers = {} if headers is None else headers.copy()
 
         # (1) communicate lower bound on version handled in the outgoing request
         #     (set `Accept` header if `media_type` or `ask_version` defined)

--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -125,6 +125,11 @@ class DWaveAPIClient:
         To make sure the session is closed, call :meth:`.close`, or use the
         context manager form (as show in the example below).
 
+    Note:
+        Since `requests.Session` is **not thread-safe**, neither is
+        :class:`DWaveAPIClient`. It's best to create (and dispose) a new client
+        on demand, in each thread.
+
     Example:
         with DWaveAPIClient(endpoint='...', timeout=(5, 600)) as client:
             client.session.get('...')

--- a/dwave/cloud/api/constants.py
+++ b/dwave/cloud/api/constants.py
@@ -23,6 +23,11 @@ DEFAULT_METADATA_API_ENDPOINT = 'https://cloud.dwavesys.com/metadata/v1/'
 DEFAULT_REGION = 'na-west-1'
 
 
+# Default API version
+DEFAULT_API_MEDIA_TYPE = 'application/vnd.dwave+json'
+DEFAULT_API_RESPONSE_VERSION = '1.0.0'
+
+
 class ProblemStatus(str, enum.Enum):
     """Solver API problem status values.
 

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -164,16 +164,15 @@ class Regions(ResourceBase):
     def __init__(self, **config):
         self.client = MetadataAPIClient(**config)
 
-    # Content-Type: application/vnd.dwave.metadata.regions+json; version=1.0.0
-    @accepts(media_type='application/vnd.dwave.metadata.regions+json', accept_version='>=1,<2')
+    @accepts(media_type='application/vnd.dwave.metadata.regions+json', accept_version='~=1.0')
     def list_regions(self) -> List[models.Region]:
         path = ''
         response = self.session.get(path)
         regions = response.json()
         return parse_obj_as(List[models.Region], regions)
 
-    # Content-Type: application/vnd.dwave.metadata.region+json; version=1.0.0
-    @accepts(media_type='application/vnd.dwave.metadata.region+json', accept_version='>=1,<2')
+    # XXX: currently, API returns a wrong media-type (regions, instead of region)
+    @accepts(media_type='application/vnd.dwave.metadata.regions+json', accept_version='~=1.0')
     def get_region(self, code: str) -> models.Region:
         path = '{}'.format(code)
         response = self.session.get(path)
@@ -185,14 +184,14 @@ class Solvers(ResourceBase):
 
     resource_path = 'solvers/'
 
-    # Content-Type: application/vnd.dwave.sapi.solver-definition-list+json; version=2.0.0
+    @accepts(media_type='application/vnd.dwave.sapi.solver-definition-list+json', accept_version='~=2.0')
     def list_solvers(self) -> List[models.SolverConfiguration]:
         path = 'remote/'
         response = self.session.get(path)
         solvers = response.json()
         return parse_obj_as(List[models.SolverConfiguration], solvers)
 
-    # Content-Type: application/vnd.dwave.sapi.solver-definition+json; version=2.0.0
+    @accepts(media_type='application/vnd.dwave.sapi.solver-definition+json', accept_version='~=2.0')
     def get_solver(self, solver_id: str) -> models.SolverConfiguration:
         path = 'remote/{}'.format(solver_id)
         response = self.session.get(path)
@@ -204,7 +203,7 @@ class Problems(ResourceBase):
 
     resource_path = 'problems/'
 
-    # Content-Type: application/vnd.dwave.sapi.problems+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problems+json', accept_version='>=2.1,<3')
     def list_problems(self, *,
                       id: str = None,
                       label: str = None,
@@ -233,7 +232,7 @@ class Problems(ResourceBase):
         statuses = response.json()
         return parse_obj_as(List[models.ProblemStatus], statuses)
 
-    # Content-Type: application/vnd.dwave.sapi.problem+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problem+json', accept_version='>=2.1,<3')
     def get_problem(self, problem_id: str) -> models.ProblemStatusMaybeWithAnswer:
         """Retrieve problem short status and answer if answer is available."""
         path = '{}'.format(problem_id)
@@ -241,7 +240,7 @@ class Problems(ResourceBase):
         status = response.json()
         return models.ProblemStatusMaybeWithAnswer.parse_obj(status)
 
-    # Content-Type: application/vnd.dwave.sapi.problems+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problems+json', accept_version='>=2.1,<3')
     def get_problem_status(self, problem_id: str) -> models.ProblemStatus:
         """Retrieve short status of a single problem."""
         path = ''
@@ -250,8 +249,8 @@ class Problems(ResourceBase):
         status = response.json()[0]
         return models.ProblemStatus.parse_obj(status)
 
-    # Content-Type: application/vnd.dwave.sapi.problems+json; version=2.1.0
     # XXX: @pydantic.validate_arguments
+    @accepts(media_type='application/vnd.dwave.sapi.problems+json', accept_version='>=2.1,<3')
     def get_problem_statuses(self, problem_ids: List[str]) -> List[models.ProblemStatus]:
         """Retrieve short problem statuses for a list of problems."""
         if not isinstance(problem_ids, list):
@@ -265,7 +264,7 @@ class Problems(ResourceBase):
         statuses = response.json()
         return parse_obj_as(List[models.ProblemStatus], statuses)
 
-    # Content-Type: application/vnd.dwave.sapi.problem-data+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problem-data+json', accept_version='>=2.1,<3')
     def get_problem_info(self, problem_id: str) -> models.ProblemInfo:
         """Retrieve complete problem info."""
         path = '{}/info'.format(problem_id)
@@ -273,7 +272,7 @@ class Problems(ResourceBase):
         info = response.json()
         return models.ProblemInfo.parse_obj(info)
 
-    # Content-Type: application/vnd.dwave.sapi.problem-answer+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problem-answer+json', accept_version='>=2.1,<3')
     def get_problem_answer(self, problem_id: str) -> models.ProblemAnswer:
         """Retrieve problem answer."""
         path = '{}/answer'.format(problem_id)
@@ -281,14 +280,14 @@ class Problems(ResourceBase):
         answer = response.json()['answer']
         return models.ProblemAnswer.parse_obj(answer)
 
-    # Content-Type: application/vnd.dwave.sapi.problem-message+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problem-message+json', accept_version='>=2.1,<3')
     def get_problem_messages(self, problem_id: str) -> List[dict]:
         """Retrieve list of problem messages."""
         path = '{}/messages'.format(problem_id)
         response = self.session.get(path)
         return response.json()
 
-    # Content-Type: application/vnd.dwave.sapi.problems+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problems+json', accept_version='>=2.1,<3')
     def submit_problem(self, *,
                        data: models.ProblemData,
                        params: dict,
@@ -308,7 +307,7 @@ class Problems(ResourceBase):
         rtype = get_type_hints(self.submit_problem)['return']
         return parse_obj_as(rtype, response.json())
 
-    # Content-Type: application/vnd.dwave.sapi.problems+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problems+json', accept_version='>=2.1,<3')
     def submit_problems(self, problems: List[models.ProblemJob]) -> \
             List[Union[models.ProblemInitialStatus, models.ProblemSubmitError]]:
         """Asynchronous multi-problem submit, returning initial statuses."""
@@ -320,7 +319,7 @@ class Problems(ResourceBase):
         rtype = get_type_hints(self.submit_problems)['return']
         return parse_obj_as(rtype, response.json())
 
-    # Content-Type: application/vnd.dwave.sapi.problem+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problem+json', accept_version='>=2.1,<3')
     def cancel_problem(self, problem_id: str) -> \
             Union[models.ProblemStatus, models.ProblemCancelError]:
         """Initiate problem cancel by problem id."""
@@ -329,7 +328,7 @@ class Problems(ResourceBase):
         rtype = get_type_hints(self.cancel_problem)['return']
         return parse_obj_as(rtype, response.json())
 
-    # Content-Type: application/vnd.dwave.sapi.problems+json; version=2.1.0
+    @accepts(media_type='application/vnd.dwave.sapi.problems+json', accept_version='>=2.1,<3')
     def cancel_problems(self, problem_ids: List[str]) -> \
             List[Union[models.ProblemStatus, models.ProblemCancelError]]:
         """Initiate problem cancel for a list of problems."""

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -77,15 +77,16 @@ class ResourceBase:
                             media_type: Optional[str] = None,
                             ask_version: Optional[str] = None,
                             accept_version: Optional[str] = None,
-                            **params):
+                            params: Optional[dict] = None):
         # (1) communicate lower bound on version handled in the outgoing request, and
         # (2) validate version supported in the incoming response
         if media_type is not None:
             components = [media_type]
             if ask_version:
                 components.append(f'version={ask_version}')
-            for k,v in params.items():
-                components.append(f'{k}={v}')
+            if params is not None:
+                for k,v in params.items():
+                    components.append(f'{k}={v}')
             session.headers['Accept'] = '; '.join(components)
 
         if accept_version is not None:

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -169,8 +169,7 @@ class Regions(ResourceBase):
         regions = response.json()
         return parse_obj_as(List[models.Region], regions)
 
-    # XXX: currently, API returns a wrong media-type (regions, instead of region)
-    @accepts(media_type='application/vnd.dwave.metadata.regions+json', accept_version='~=1.0')
+    @accepts(media_type='application/vnd.dwave.metadata.region+json', accept_version='~=1.0')
     def get_region(self, code: str) -> models.Region:
         path = '{}'.format(code)
         response = self.session.get(path)

--- a/releasenotes/notes/enforce-api-response-version-bb25a12d4629974e.yaml
+++ b/releasenotes/notes/enforce-api-response-version-bb25a12d4629974e.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add ``accepts`` decorator for declaring accepted media type and response
+    format version (range) on ``dwave.cloud.api.Resource`` methods.
+upgrade:
+  - |
+    Enforce D-Wave API response format version on all ``cloud.api`` resources.

--- a/releasenotes/notes/enforce-api-response-version-bb25a12d4629974e.yaml
+++ b/releasenotes/notes/enforce-api-response-version-bb25a12d4629974e.yaml
@@ -1,6 +1,10 @@
 ---
 features:
   - |
+    Add ``VersionedAPISession``, a ``requests.Session`` subclass (more precisely,
+    further specialized ``LoggingSession``) that enforces conformance of API
+    response version with supported version range(s).
+  - |
     Add ``accepts`` decorator for declaring accepted media type and response
     format version (range) on ``dwave.cloud.api.Resource`` methods.
 upgrade:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click>=7
 plucky>=0.4.3
 diskcache>=5.2.1
 packaging>=19
+werkzeug>=2.2
 
 # optional bqm support
 # note: dqm supported in dimod>0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dateutil>=2.7
 click>=7
 plucky>=0.4.3
 diskcache>=5.2.1
+packaging>=19
 
 # optional bqm support
 # note: dqm supported in dimod>0.9.6

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ python_requires = '>=3.7'
 # Package requirements, minimal pinning
 install_requires = ['requests[socks]>=2.18', 'pydantic>=1.7.3', 'homebase>=1.0',
                     'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3',
-                    'diskcache>=5.2.1', 'packaging>=19']
+                    'diskcache>=5.2.1', 'packaging>=19', 'werkzeug>=2.2']
 
 # Package extras requirements
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ python_requires = '>=3.7'
 # Package requirements, minimal pinning
 install_requires = ['requests[socks]>=2.18', 'pydantic>=1.7.3', 'homebase>=1.0',
                     'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3',
-                    'diskcache>=5.2.1']
+                    'diskcache>=5.2.1', 'packaging>=19']
 
 # Package extras requirements
 extras_require = {

--- a/tests/api/mocks.py
+++ b/tests/api/mocks.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import uuid
 from typing import Union, Tuple
 
@@ -151,7 +150,7 @@ class SapiMockResponses:
     def cancel_reply(self, **kwargs) -> dict:
         """A reply saying a problem was canceled."""
 
-        return {
+        response = {
             "status": "CANCELLED",
             "solved_on": utcrel(-10).isoformat(),
             "solver": self.solver_id,

--- a/tests/api/resources/__init__.py
+++ b/tests/api/resources/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from tests.api.resources.test_resource_base import *
 from tests.api.resources.test_regions import *
 from tests.api.resources.test_solvers import *
 from tests.api.resources.test_problems import *

--- a/tests/api/resources/test_regions.py
+++ b/tests/api/resources/test_regions.py
@@ -25,7 +25,7 @@ from tests import config
 
 class TestMockRegions(unittest.TestCase):
     """Test request formation and response parsing (including error handling)
-    works correctly for all :class:`dwave.cloud.api.resources.Solvers` methods.
+    works correctly for all :class:`dwave.cloud.api.resources.Regions` methods.
     """
 
     endpoint = 'http://test.com/path/'

--- a/tests/api/resources/test_resource_base.py
+++ b/tests/api/resources/test_resource_base.py
@@ -1,0 +1,68 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from urllib.parse import urljoin
+
+import requests_mock
+from pydantic import parse_obj_as, BaseModel
+
+from dwave.cloud.api import exceptions
+from dwave.cloud.api.resources import ResourceBase
+
+
+class MathResource(ResourceBase):
+    """A prototypical resource, implementing an interface to a 2-integer adder."""
+
+    resource_path = 'math/'
+
+    class AddResult(BaseModel):
+        out: int
+
+    def add(self, in1: int, in2: int) -> int:
+        path = 'add/'
+        response = self.session.get(path, params=dict(in1=in1, in2=in2))
+        result = response.json()
+        return parse_obj_as(MathResource.AddResult, result).out
+
+    def nonexisting(self):
+        return self.session.get('nonexisting')
+
+
+class TestMockResource(unittest.TestCase):
+    """Test request formation and response parsing (including error
+    handling and api version validation) works correctly for all
+    :class:`dwave.cloud.api.resources.ResourceBase` methods.
+    """
+
+    endpoint = 'http://test.com/path/'
+
+    def setUp(self):
+        self.add_uri = urljoin(urljoin(self.endpoint, MathResource.resource_path), 'add/')
+
+    @requests_mock.Mocker()
+    def test_basic_flow(self, m):
+        m.get(urljoin(self.add_uri, '?in1=1&in2=2'), json=dict(out=3))
+
+        resource = MathResource(endpoint=self.endpoint)
+        res = resource.add(1, 2)
+        self.assertEqual(res, 3)
+
+    @requests_mock.Mocker()
+    def test_nonexisting_path(self, m):
+        m.get(requests_mock.ANY, status_code=404)
+
+        resource = MathResource(endpoint=self.endpoint)
+        with self.assertRaises(exceptions.ResourceNotFoundError):
+            resource.nonexisting()

--- a/tests/api/resources/test_resource_base.py
+++ b/tests/api/resources/test_resource_base.py
@@ -129,7 +129,7 @@ class TestMockResource(unittest.TestCase):
         # return exactly version asked for
         def json_callback(request: requests.Request, context):
             accept = request.headers['Accept']
-            version = re.search('version=(\d+(\.\d+)?)', accept).group(1)
+            version = re.search(r'version=(\d+(\.\d+)?)', accept).group(1)
             context.headers['Content-Type'] = f'application/vnd.dwave.api.mock+json; version={version}'
             return dict(v=version)
         m.get(urljoin(self.base_uri, 'version/'), json=json_callback)

--- a/tests/api/test_api_clients.py
+++ b/tests/api/test_api_clients.py
@@ -141,6 +141,36 @@ class TestRequests(unittest.TestCase):
             client.session.get('/path')
             self.assertEqual(client.session.history[-1].request.path_url, '/path')
 
+    @requests_mock.Mocker()
+    def test_api_version_validation(self, m):
+        """API response version validation works."""
+
+        baseurl = 'https://test.com'
+        config = dict(endpoint=baseurl)
+        media_type = 'application/vnd.dwave.api.mock+json'
+        version = '1.2.3'
+
+        path, data = 'version', dict(v=version)
+
+        m.get(requests_mock.ANY, status_code=404)
+        m.get(f"{baseurl}/{path}", json=data,
+              headers={'Content-Type': f'{media_type}; version={version}'})
+
+        with DWaveAPIClient(**config) as client:
+            # nominal
+            client.session.set_accept(media_type=media_type, accept_version='~=1.2.0')
+            self.assertEqual(client.session.get(path).json(), data)
+
+            # wrong type
+            client.session.set_accept(media_type='wrong', accept_version='~=1.2.0')
+            with self.assertRaisesRegex(exceptions.ResourceBadResponseError, r'^Received media type'):
+                self.assertEqual(client.session.get(path).json(), data)
+
+            # wrong version
+            client.session.set_accept(media_type=media_type, accept_version='>2')
+            with self.assertRaisesRegex(exceptions.ResourceBadResponseError, r'^API response format version'):
+                self.assertEqual(client.session.get(path).json(), data)
+
 
 class TestResponseParsing(unittest.TestCase):
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,6 +24,7 @@ import warnings
 import unittest
 from unittest import mock
 from contextlib import contextmanager
+from collections import defaultdict
 
 import requests
 from plucky import merge
@@ -705,6 +706,8 @@ class MultiRegionSupport(unittest.TestCase):
 
         def _mocked_session():
             session = mock.Mock()
+            session.headers = {}
+            session.hooks = defaultdict(list)
 
             def get(url, **kwargs):
                 response = mock.Mock(['text', 'json'])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -720,7 +720,7 @@ class MultiRegionSupport(unittest.TestCase):
 
         with mock.patch("dwave.cloud.config.open", iterable_mock_open(config_body)):
             with mock.patch.multiple(Client._fetch_available_regions._cached, cache={}):
-                with mock.patch("dwave.cloud.client.base.api.Regions._session", _mocked_session()):
+                with mock.patch("dwave.cloud.client.base.api.Regions._session", _mocked_session(), create=True):
                     # note: we specify config_file, otherwise reading from files
                     # might be skipped altogether if zero config files found on disk
                     # (i.e. config open mock above fails on CI)


### PR DESCRIPTION
Implement D-Wave API response _data format_ and _version_ validation for every REST API resource method implemented in `dwave.cloud.api.resources.*`, i.e. `Regions`, `Solvers` and `Problems`.

For now, don't be strict -- skip the check if the response omits `Content-Type` (media type). We might want to implement a strict mode later.

In case the client receives an unsupported response version, we fail with `ResourceBadResponseError`, prompting the user to upgrade the client.