### PR TITLE
Fix pydantic upper bound

### DIFF
--- a/releasenotes/notes/fix-pydantic-upper-bound-b1020734e2c04c63.yaml
+++ b/releasenotes/notes/fix-pydantic-upper-bound-b1020734e2c04c63.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Constrain ``pydantic`` version, as V2 introduces major backwards
+    incompatible changes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests[socks]>=2.18
-pydantic>=1.7.3
+pydantic>=1.7.3,<2
 homebase>=1.0.0
 python-dateutil>=2.7
 click>=7

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(package_info_path, encoding='utf-8') as f:
 python_requires = '>=3.7'
 
 # Package requirements, minimal pinning
-install_requires = ['requests[socks]>=2.18', 'pydantic>=1.7.3', 'homebase>=1.0',
+install_requires = ['requests[socks]>=2.18', 'pydantic>=1.7.3,<2', 'homebase>=1.0',
                     'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3',
                     'diskcache>=5.2.1', 'packaging>=19', 'werkzeug>=2.2']
 


### PR DESCRIPTION
This is a stop-gap measure until we adapt the code for pydantic v2. Current 1.10.X branch should be maintained for about a year.