### PR TITLE
Fix `backoff_max` for `urllib3>=2` retried requests

### DIFF
--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -320,9 +320,10 @@ class DWaveAPIClient:
 
         retry = urllib3.Retry(**kwargs)
 
-        # note: `Retry.BACKOFF_MAX` can't be set on construction
+        # note: prior to `urllib3==2`, backoff_max had to be set manually on object
         if backoff_max is not None:
-            retry.BACKOFF_MAX = backoff_max
+            # handle `urllib3>=1.21.1,<1.27` AND `urllib3>=1.21.1,<3`
+            retry.BACKOFF_MAX = retry.backoff_max = backoff_max
 
         return retry
 

--- a/releasenotes/notes/support-urllib3-v2-5c5a2cb29a47b43d.yaml
+++ b/releasenotes/notes/support-urllib3-v2-5c5a2cb29a47b43d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Correctly set `backoff_max` time for retried requests when ``urllib3>=2.0``
+    is used.
+    See `#566 <https://github.com/dwavesystems/dwave-cloud-client/issues/566>`_.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -555,7 +555,8 @@ class ClientConstruction(unittest.TestCase):
         self.assertEqual(retry.redirect, opts['http_retry_redirect'])
         self.assertEqual(retry.status, opts['http_retry_status'])
         self.assertEqual(retry.backoff_factor, opts['http_retry_backoff_factor'])
-        self.assertEqual(retry.BACKOFF_MAX, opts['http_retry_backoff_max'])
+        backoff_max = getattr(retry, 'backoff_max', getattr(retry, 'BACKOFF_MAX'))
+        self.assertEqual(backoff_max, opts['http_retry_backoff_max'])
 
     def test_http_retry_params_from_config(self):
         retry_opts = {


### PR DESCRIPTION
Close #566.