### PR TITLE
Add OAuth 2.0 Authorization Code exchange flow

### DIFF
--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -312,11 +312,11 @@ class DWaveAPIClient:
         self.session = self._create_session(self.config)
 
     @classmethod
-    def from_config_model(cls, config: ClientConfig, **kwargs):
+    def from_config_model(cls, config: ClientConfig, **options):
         """Create class instance based on a
         :class:`~dwave.cloud.config.models.ClientConfig` config.
         """
-        logger.trace(f"{cls.__name__}.from_config_model(config={config!r}, **{kwargs!r})")
+        logger.trace(f"{cls.__name__}.from_config_model(config={config!r}, **{options!r})")
 
         if config.headers:
             headers = config.headers.copy()
@@ -336,8 +336,8 @@ class DWaveAPIClient:
             verify=not config.permissive_ssl,
         )
 
-        # context-sensitive config update
-        update_config(opts, kwargs)
+        # add class-specific options not existing in ClientConfig
+        opts.update(**options)
 
         return cls(**opts)
 

--- a/dwave/cloud/auth/__init__.py
+++ b/dwave/cloud/auth/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OAuth 2.0 Authorization Code flow helpers for authorizing Ocean SDK access
+to Leap API.
+"""
+
+from .flows import *

--- a/dwave/cloud/auth/config.py
+++ b/dwave/cloud/auth/config.py
@@ -1,0 +1,24 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# XXX: update before releasing 0.11.0
+# TODO: make it externally configurable
+OCEAN_SDK_CLIENT_ID = '968678'
+
+OCEAN_SDK_SCOPES = (
+    'openid',
+    'get_token',
+)
+
+LEAP_OIDC_ISSUER_PATH = '/leap/openid/'

--- a/dwave/cloud/auth/flows.py
+++ b/dwave/cloud/auth/flows.py
@@ -82,7 +82,7 @@ class AuthFlow:
         """Update OAuth2Session/requests.Session with config values for:
         ``cert``, ``cookies``, ``headers``, ``proxies``, ``timeout``, ``verify``.
         """
-        self.session.headers.update(config.get('headers', {}))
+        self.session.headers.update(config.get('headers') or {})
         self.session.default_timeout = config.get('timeout', None)
 
         for key in ('cert', 'cookies', 'proxies', 'verify'):

--- a/dwave/cloud/auth/flows.py
+++ b/dwave/cloud/auth/flows.py
@@ -1,0 +1,73 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from authlib.integrations.requests_client import OAuth2Session
+from authlib.common.security import generate_token
+
+
+__all__ = ['AuthFlow']
+
+logger = logging.getLogger(__name__)
+
+
+class AuthFlow:
+    """`OAuth 2.0 Authorization Code`_ exchange flow with `PKCE`_ extension
+    for public (secretless) clients.
+
+    .. _OAuth 2.0 Authorization Code:
+        https://datatracker.ietf.org/doc/html/rfc6749#section-4.1
+    .. _PKCE:
+        https://datatracker.ietf.org/doc/html/rfc7636
+    """
+
+    def __init__(self,
+                 client_id: str,
+                 scopes: Sequence[str],
+                 redirect_uri: str,
+                 authorization_endpoint: str,
+                 token_endpoint: str,
+                 ):
+        self.client_id = client_id
+        self.scopes = ' '.join(scopes)
+        self.redirect_uri = redirect_uri
+        self.authorization_endpoint = authorization_endpoint
+        self.token_endpoint = token_endpoint
+
+        self.session = OAuth2Session(
+            client_id=client_id, scope=scopes, redirect_uri=redirect_uri,
+            code_challenge_method='S256')
+
+    def get_authorization_url(self) -> str:
+        self.state = generate_token(30)
+        self.code_verifier = generate_token(48)
+
+        url, _ = self.session.create_authorization_url(
+            url=self.authorization_endpoint,
+            state=self.state,
+            code_verifier=self.code_verifier)
+
+        return url
+
+    # todo: propagate headers, currently via kwargs
+    def fetch_token(self, code, **kwargs) -> dict:
+        return self.session.fetch_token(
+            url=self.token_endpoint,
+            grant_type='authorization_code',
+            code=code,
+            **kwargs)

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -20,8 +20,9 @@ import random
 import logging
 import platform
 import itertools
-import numbers
 import warnings
+import inspect
+import numbers
 
 from collections import OrderedDict
 from urllib.parse import urljoin
@@ -835,6 +836,10 @@ def set_loglevel(logger, level_name):
     level = parse_loglevel(level_name)
     logger.setLevel(level)
     logger.info("Log level for %r namespace set to %r", logger.name, level)
+
+def pretty_argvalues():
+    """Pretty-formatted function call arguments, from the caller's frame."""
+    return inspect.formatargvalues(*inspect.getargvalues(inspect.currentframe().f_back))
 
 
 def get_contrib_config():

--- a/releasenotes/notes/add-oauth2-authorization-flow-96ab69c1d3d4817e.yaml
+++ b/releasenotes/notes/add-oauth2-authorization-flow-96ab69c1d3d4817e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add OAuth 2.0 Authorization Code exchange flow to enable users to authorize
+    Ocean SDK to access Leap API on their behalf.

--- a/releasenotes/notes/add-oauth2-authorization-flow-96ab69c1d3d4817e.yaml
+++ b/releasenotes/notes/add-oauth2-authorization-flow-96ab69c1d3d4817e.yaml
@@ -3,3 +3,4 @@ features:
   - |
     Add OAuth 2.0 Authorization Code exchange flow to enable users to authorize
     Ocean SDK to access Leap API on their behalf.
+    See `#564 <https://github.com/dwavesystems/dwave-cloud-client/issues/564>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ diskcache>=5.2.1
 packaging>=19
 werkzeug>=2.2
 typing-extensions>=4.5.0
+authlib>=1.2,<2
 
 # optional bqm support
 # note: dqm supported in dimod>0.9.6

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ python_requires = '>=3.8'
 install_requires = ['requests[socks]>=2.18', 'pydantic>=2,<3', 'homebase>=1.0',
                     'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3',
                     'diskcache>=5.2.1', 'packaging>=19', 'werkzeug>=2.2',
-                    'typing-extensions>=4.5.0',
+                    'typing-extensions>=4.5.0', 'authlib>=1.2,<2',
                     ]
 
 # Package extras requirements

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/auth/test_flows.py
+++ b/tests/auth/test_flows.py
@@ -1,0 +1,77 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from urllib.parse import urlsplit, parse_qs, parse_qsl
+
+import requests_mock
+
+from dwave.cloud.auth.flows import AuthFlow
+
+
+class TestAuthFlow(unittest.TestCase):
+
+    def setUp(self):
+        self.client_id = '123'
+        self.scopes = ('scope-a', 'scope-b')
+        self.redirect_uri_oob = 'oob'
+        self.authorization_endpoint = 'https://example.com/authorize'
+        self.token_endpoint = 'https://example.com/token'
+
+    def test_auth_url(self):
+        flow = AuthFlow(client_id=self.client_id,
+                        scopes=self.scopes,
+                        redirect_uri=self.redirect_uri_oob,
+                        authorization_endpoint=self.authorization_endpoint,
+                        token_endpoint=self.token_endpoint)
+
+        url = flow.get_authorization_url()
+        q = dict(parse_qsl(urlsplit(url).query))
+
+        self.assertTrue(url.startswith(self.authorization_endpoint))
+        self.assertEqual(q['response_type'], 'code')
+        self.assertEqual(q['client_id'], self.client_id)
+        self.assertEqual(q['redirect_uri'], self.redirect_uri_oob)
+        self.assertEqual(q['scope'], ' '.join(self.scopes))
+        self.assertIn('state', q)
+        # pkce
+        self.assertIn('code_challenge', q)
+        self.assertEqual(q['code_challenge_method'], 'S256')
+
+    @requests_mock.Mocker()
+    def test_fetch_token(self, m):
+        # mock the token_endpoint
+        code = '123456'
+        token = dict(access_token='123', refresh_token='456', id_token='789')
+        expected_params = dict(
+            grant_type='authorization_code', client_id=self.client_id,
+            redirect_uri=self.redirect_uri_oob, code=code)
+
+        def post_body_matcher(request):
+            params = dict(parse_qsl(request.text))
+            return params == expected_params
+
+        m.get(requests_mock.ANY, status_code=404)
+        m.post(requests_mock.ANY, status_code=404)
+        m.post(self.token_endpoint, additional_matcher=post_body_matcher, json=token)
+
+        # verify token fetch flow
+        flow = AuthFlow(client_id=self.client_id,
+                        scopes=self.scopes,
+                        redirect_uri=self.redirect_uri_oob,
+                        authorization_endpoint=self.authorization_endpoint,
+                        token_endpoint=self.token_endpoint)
+
+        response = flow.fetch_token(code=code)
+        self.assertEqual(response, token)


### PR DESCRIPTION
Implements #564, but just for the out-of-band exchange case.

In a follow-up PR:
- Ocean client id external configurability
- code exchange via local callback (requires #563 first)