### PR TITLE
Add support for redirect and OOB flows on OAuth 2.0 authorization

### DIFF
--- a/dwave/cloud/auth/flows.py
+++ b/dwave/cloud/auth/flows.py
@@ -15,13 +15,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional, Sequence
-from urllib.parse import urljoin
+import webbrowser
+from operator import sub
+from typing import Any, Callable, Dict, Optional, Union, Sequence
+from urllib.parse import urljoin, parse_qsl
 
 from authlib.integrations.requests_client import OAuth2Session
 from authlib.common.security import generate_token
 
 from dwave.cloud.auth.config import OCEAN_SDK_CLIENT_ID, OCEAN_SDK_SCOPES
+from dwave.cloud.auth.server import SingleRequestAppServer, RequestCaptureApp
 from dwave.cloud.config.models import ClientConfig
 from dwave.cloud.utils import pretty_argvalues
 
@@ -67,7 +70,6 @@ class AuthFlow:
                  ):
         self.client_id = client_id
         self.scopes = ' '.join(scopes)
-        self.redirect_uri = redirect_uri
         self.authorization_endpoint = authorization_endpoint
         self.token_endpoint = token_endpoint
 
@@ -92,6 +94,14 @@ class AuthFlow:
         for key in ('cert', 'cookies', 'proxies', 'verify'):
             if key in config:
                 setattr(self.session, key, config[key])
+
+    @property
+    def redirect_uri(self):
+        return self.session.redirect_uri
+
+    @redirect_uri.setter
+    def redirect_uri(self, value):
+        self.session.redirect_uri = value
 
     def get_authorization_url(self) -> str:
         self.state = generate_token(30)
@@ -155,6 +165,16 @@ class LeapAuthFlow(AuthFlow):
 
     _OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 
+    _VISIT_AUTH_MSG = 'Please visit the following URL to authorize Ocean: '
+    _INPUT_CODE_MSG = 'Authorization code: '
+
+    _REDIRECT_HOST = '127.0.0.1'
+    _REDIRECT_PORT_RANGE = (36000, 36050)
+    _REDIRECT_DONE_MSG = ('The authorization code exchange flow has completed. '
+                          'You can now close this browser tab.')
+
+    _AUTH_TIMEOUT_MSG = 'Authorization flow did not complete in the allotted time.'
+
     # note: in the future we might want to replace these url resolvers with a
     # OpenID Provider Metadata server query
     @staticmethod
@@ -202,3 +222,72 @@ class LeapAuthFlow(AuthFlow):
             authorization_endpoint=authorization_endpoint,
             token_endpoint=token_endpoint,
             session_config=session_config)
+
+    def run_oob_flow(self):
+        """Run the OAuth 2.0 Authorization Code exchange flow, using the out of
+        band code exchange.
+
+        After authorizing access by visiting the authorization URL displayed,
+        user has to copy the authorization code and paste it back in their
+        terminal. On successful completion Leap API access and refresh tokens
+        are returned.
+        """
+        self.redirect_uri = self._OOB_REDIRECT_URI
+
+        url = self.get_authorization_url()
+        print(self._VISIT_AUTH_MSG, url)
+
+        code = input(self._INPUT_CODE_MSG)
+        return self.fetch_token(code=code)
+
+    def run_redirect_flow(self, *, open_browser: Union[bool,Callable] = False,
+                          timeout: Optional[float] = None):
+        """Run the OAuth 2.0 Authorization Code exchange flow, using a redirect
+        URI hosted on a local server.
+
+        This flow is the preferred one, but can only be used if you can access
+        localhost addresses serviced by Ocean running in your (development)
+        environment from your browser.
+
+        After authorizing access by visiting the authorization URL displayed,
+        the flow will continue on the localhost redirect URI. The authorization
+        code is exchanged automatically, and on successful completion, Leap API
+        access and refresh tokens are returned.
+
+        Example::
+            from dwave.cloud.auth.flows import LeapAuthFlow
+            from dwave.cloud.config import load_config, validate_config_v1
+
+            config = validate_config_v1(load_config())
+            flow = LeapAuthFlow.from_config_model(config)
+
+            flow.run_redirect_flow(open_browser=True)
+
+        """
+        app = RequestCaptureApp(message=self._REDIRECT_DONE_MSG)
+        srv = SingleRequestAppServer(
+            host=self._REDIRECT_HOST,
+            base_port=self._REDIRECT_PORT_RANGE[0],
+            max_port=self._REDIRECT_PORT_RANGE[1],
+            linear_tries=max(1, -sub(*self._REDIRECT_PORT_RANGE) // 10),
+            app=app)
+        srv.start()
+
+        self.redirect_uri = srv.root_url
+
+        url = self.get_authorization_url()
+        print(self._VISIT_AUTH_MSG, url)
+        if open_browser:
+            if callable(open_browser):
+                open_browser(url)
+            else:
+                webbrowser.open(url)
+
+        try:
+            srv.wait_shutdown(timeout)
+        except TimeoutError:
+            print(self._AUTH_TIMEOUT_MSG)
+            return
+
+        q = dict(parse_qsl(app.query))
+        return self.fetch_token(code=q.get('code'), state=q.get('state'))

--- a/dwave/cloud/auth/server.py
+++ b/dwave/cloud/auth/server.py
@@ -213,9 +213,14 @@ class BackgroundAppServer(threading.Thread):
 
         return 'http://{}:{}/'.format(*self.server.server_address)
 
-    def wait_shutdown(self, timeout=None):
+    def wait_shutdown(self, timeout: Optional[float] = None):
+        """Waits for ``timeout`` in seconds for server to shutdown before
+        raising a ``TimeoutError``.
+        """
         logger.debug(f"{type(self).__name__}.wait_shutdown(timeout={timeout})")
         self.join(timeout)
+        if self.is_alive():
+            raise TimeoutError("Server has not shut down in the allotted timeout.")
 
 
 class SingleRequestAppServer(BackgroundAppServer):

--- a/dwave/cloud/auth/server.py
+++ b/dwave/cloud/auth/server.py
@@ -207,6 +207,10 @@ class BackgroundAppServer(threading.Thread):
         self.join()
 
     def root_url(self):
+        if not self.is_alive():
+            # make sure server runs in a thread
+            self.start()
+
         return 'http://{}:{}/'.format(*self.server.server_address)
 
     def wait_shutdown(self, timeout=None):

--- a/releasenotes/notes/add-auth-redirect-flow-403db55009620576.yaml
+++ b/releasenotes/notes/add-auth-redirect-flow-403db55009620576.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    For OAuth 2.0 Authorization Code exchange flow, add support for both the
+    redirect flow, and the "out of band" flow.
+    See `#564 <https://github.com/dwavesystems/dwave-cloud-client/issues/564>`_.

--- a/tests/auth/test_server.py
+++ b/tests/auth/test_server.py
@@ -54,6 +54,7 @@ class TestPortsGenerator(unittest.TestCase):
 
 class TestBackgroundAppServer(unittest.TestCase):
 
+    @unittest.mock.patch('threading.excepthook', lambda *a, **kw: None)
     def test_port_search(self):
         base_port = 64000
 

--- a/tests/auth/test_server.py
+++ b/tests/auth/test_server.py
@@ -92,10 +92,10 @@ class TestBackgroundAppServer(unittest.TestCase):
         srv.start()
 
         # test root url
-        self.assertEqual(srv.root_url(), f'http://127.0.0.1:{srv.server.server_port}/')
+        self.assertEqual(srv.root_url, f'http://127.0.0.1:{srv.server.server_port}/')
 
         # test response
-        self.assertEqual(requests.get(srv.root_url()).text, response)
+        self.assertEqual(requests.get(srv.root_url).text, response)
 
         srv.stop()
 
@@ -114,7 +114,7 @@ class TestBackgroundAppServer(unittest.TestCase):
             host='127.0.0.1', base_port=base_port, max_port=base_port+9, app=app)
         srv.start()
 
-        url = srv.root_url()
+        url = srv.root_url
         def get_url(url, timeout=10):
             return requests.get(url, timeout=timeout).text
 
@@ -191,7 +191,7 @@ class TestBackgroundAppServer(unittest.TestCase):
 class TestSingleRequestAppServer(unittest.TestCase):
 
     def test_function(self):
-        base_port = 64040
+        base_port = 64050
         response = 'It works!'
 
         def app(environ, start_response):
@@ -203,7 +203,7 @@ class TestSingleRequestAppServer(unittest.TestCase):
         srv.start()
 
         # test response
-        self.assertEqual(requests.get(srv.root_url()).text, response)
+        self.assertEqual(requests.get(srv.root_url).text, response)
 
         # test server shuts down within reasonable time
         srv.wait_shutdown(timeout=0.5)

--- a/tests/auth/test_server.py
+++ b/tests/auth/test_server.py
@@ -67,6 +67,14 @@ class TestBackgroundAppServer(unittest.TestCase):
         second.start()
         self.assertEqual(second.server.server_port, base_port+1)
 
+        # test port search exhaustion
+        with self.assertRaises(RuntimeError):
+            third = BackgroundAppServer(
+                host='', base_port=base_port, max_port=base_port+1, app=None)
+            third.start()
+            third.wait_shutdown()
+            third.exception()
+
         first.stop()
         second.stop()
 

--- a/tests/auth/test_server.py
+++ b/tests/auth/test_server.py
@@ -131,13 +131,26 @@ class TestBackgroundAppServer(unittest.TestCase):
 
         srv.stop()
 
+    def test_wait_shutdown(self):
+        base_port = 64030
+        srv = BackgroundAppServer(
+            host='127.0.0.1', base_port=base_port, max_port=base_port+9, app=None)
+        srv.start()
+
+        with self.assertRaises(TimeoutError):
+            srv.wait_shutdown(0.5)
+
+        srv.stop()
+        srv.wait_shutdown()
+        self.assertFalse(srv.is_alive())
+
     def test_timeout(self):
         # XXX: not the most elegant method of checking if server closes the
         # connection after `timeout`, so we should revisit this at some point.
         # I have manually verified the behavior is correct, thought, with
         # telnet, curl and wireshark.
 
-        base_port = 64030
+        base_port = 64040
         timeout = 0.5
 
         def app(environ, start_response):


### PR DESCRIPTION
Close #564.

Left for a follow-up PR (perhaps grouped with #562):
- Ocean client id external configurability

**Note**: the two flow runners will probably be re-implemented in #565, but are provisionally given here for testing.