### PR TITLE
Add optional authorization to `dwave setup`

### DIFF
--- a/dwave/cloud/auth/flows.py
+++ b/dwave/cloud/auth/flows.py
@@ -202,7 +202,9 @@ class AuthFlow:
         return token
 
     def ensure_active_token(self):
-        is_active = self.session.ensure_active_token(token=self.session.token)
+        if not self.token:
+            return False
+        is_active = self.session.ensure_active_token(token=self.token)
         self._save_token_to_creds(self.token)
         return is_active
 

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -957,7 +957,7 @@ def setup(install_all, auth, project, oob, ask_full, verbose, output):
     auto_token = False
     if auth or oob:
         click.echo("Authorizing Leap access.\n")
-        _login(config_file=None, profile=None, oob=oob, output=output)
+        _login(config_file=None, profile=None, oob=oob, skip_valid=True, output=output)
         click.echo()
         auto_token = True
         ask_full = False

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -814,7 +814,7 @@ def _get_dist(dist_spec):
     return pkg_resources.get_distribution(dist_spec)
 
 
-def _contrib_package_maybe_installed(name):
+def _contrib_package_maybe_installed(name: str) -> bool:
     """Check if contrib package `name` is installed (even partially)."""
 
     contrib = get_contrib_packages()
@@ -939,9 +939,15 @@ def setup(install_all, auth, project, oob, ask_full, verbose, output):
         # and `dwave setup` ran without `--all` flag.
         click.echo("Optionally install non-open-source packages and "
                    "configure your environment.\n")
-        prompt = "Do you want to select non-open-source packages to install (y/n)?"
-        val = default_text_input(prompt, default='y')
-        install = val.lower() == 'y'
+
+        # Skip the prompt if all contrib packages already installed
+        if all(_contrib_package_maybe_installed(name) for name in contrib):
+            click.echo("All optional packages already installed.")
+            install = False
+        else:
+            prompt = "Do you want to select non-open-source packages to install (y/n)?"
+            val = default_text_input(prompt, default='y')
+            install = val.lower() == 'y'
         click.echo()
 
     if install:
@@ -950,12 +956,13 @@ def setup(install_all, auth, project, oob, ask_full, verbose, output):
 
     auto_token = False
     if auth or oob:
-        click.echo("Authorizing Leap access.")
+        click.echo("Authorizing Leap access.\n")
         _login(config_file=None, profile=None, oob=oob, output=output)
+        click.echo()
         auto_token = True
         ask_full = False
 
-    click.echo("Creating the D-Wave configuration file.")
+    click.echo("Creating the D-Wave configuration file.\n")
     return _config_create(config_file=None, profile=None, ask_full=ask_full,
                           auto_token=auto_token, project=project)
 

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -909,12 +909,12 @@ def _install_contrib_package(name, verbose=0, prompt=True):
               "Implies --auto-token during 'dwave config create' and it's "
               "mutually exclusive with --full.")
 @click.option('--project', 'project', default=None,
-              help='Leap project for which SAPI token is pulled. Defaults to active project.')
+              help='Leap project for which SAPI token is retrieved. Defaults to active project.')
 @click.option('--oob', default=False, is_flag=True,
               help="Same as '--auth', but using OAuth out-of-band flow. "
-              "Use when 'localhost' not available in your browser.")
+              "Use when 'localhost' is not available in your browser.")
 @click.option('--full', 'ask_full', default=False, is_flag=True,
-              help='Configure non-essential options manually (such as endpoint and solver).')
+              help='Manually configure non-essential options such as endpoint and solver.')
 @click.option('--verbose', '-v', count=True,
               help='Increase output verbosity (additive, up to 4 times)')
 @standardized_output

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -922,7 +922,7 @@ def setup(install_all, auth, project, oob, ask_full, verbose, output):
     """Setup optional Ocean packages and configuration file(s).
 
     Equivalent to running `dwave install [--all]`, followed by
-    an optional `dwave auth login [--oob]` and then by
+    an optional `dwave auth login --skip-valid [--oob]` and then by
     `dwave config create [--full] [--auto-token]`.
     """
 

--- a/releasenotes/notes/add-auth-to-dwave-setup-a0a6804a0f730851.yaml
+++ b/releasenotes/notes/add-auth-to-dwave-setup-a0a6804a0f730851.yaml
@@ -4,6 +4,6 @@ features:
     Add optional Leap authorization step to ``dwave setup`` CLI. During setup,
     we now install optional contributed packages, authorize Ocean to access Leap
     (``--auth`` and ``--oob`` flags), and finally create the configuration file,
-    optionally pulling SAPI token from Leap API (if authorized) for the currently
+    optionally retrieving SAPI token from Leap API (if authorized) for the currently
     active Leap project, or project specified with ``--project`` option.
     See `#591 <https://github.com/dwavesystems/dwave-cloud-client/issues/591>`_.

--- a/releasenotes/notes/add-auth-to-dwave-setup-a0a6804a0f730851.yaml
+++ b/releasenotes/notes/add-auth-to-dwave-setup-a0a6804a0f730851.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Add optional Leap authorization step to ``dwave setup`` CLI. During setup,
+    we now install optional contributed packages, authorize Ocean to access Leap
+    (``--auth`` and ``--oob`` flags), and finally create the configuration file,
+    optionally pulling SAPI token from Leap API (if authorized) for the currently
+    active Leap project, or project specified with ``--project`` option.
+    See `#591 <https://github.com/dwavesystems/dwave-cloud-client/issues/591>`_.

--- a/releasenotes/notes/add-skip-valid-auth-cli-option-901043cdc6f47718.yaml
+++ b/releasenotes/notes/add-skip-valid-auth-cli-option-901043cdc6f47718.yaml
@@ -2,5 +2,5 @@
 features:
   - |
     Add ``--skip-valid`` option to ``dwave auth login`` CLI. When used,
-    authorization flow will be short-circuited if Leap access token is valid, or
+    authorization flow will be skipped if Leap access token is valid or
     if it can be refreshed.

--- a/releasenotes/notes/add-skip-valid-auth-cli-option-901043cdc6f47718.yaml
+++ b/releasenotes/notes/add-skip-valid-auth-cli-option-901043cdc6f47718.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add ``--skip-valid`` option to ``dwave auth login`` CLI. When used,
+    authorization flow will be short-circuited if Leap access token is valid, or
+    if it can be refreshed.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -449,8 +449,14 @@ class TestCli(unittest.TestCase):
             self.assertIn(key, result.output)
 
 
-@isolated_environ(empty=True)
 class TestAuthCli(unittest.TestCase):
+
+    def setUp(self):
+        self.env = isolated_environ(empty=True)
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
 
     @mock.patch('dwave.cloud.auth.flows.LeapAuthFlow.from_config_model')
     def test_login(self, flow_factory):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -471,6 +471,17 @@ class TestAuthCli(unittest.TestCase):
             flow.run_redirect_flow.assert_called_once()
             self.assertEqual(result.exit_code, 0)
 
+        with self.subTest('dwave auth login --skip-valid'):
+            flow.reset_mock()
+            flow.ensure_active_token.return_value = True
+            runner = CliRunner(mix_stderr=False)
+            with runner.isolated_filesystem():
+                result = runner.invoke(cli, ['auth', 'login', '--skip-valid'])
+
+            flow.ensure_active_token.assert_called_once()
+            flow.run_redirect_flow.assert_not_called()
+            self.assertEqual(result.exit_code, 0)
+
         with self.subTest('dwave auth login --oob'):
             flow.reset_mock()
             runner = CliRunner(mix_stderr=False)


### PR DESCRIPTION
We add `--auth`, `--project` and `--oob` options to `dwave setup`.

```
$ dwave setup --help
Usage: dwave setup [OPTIONS]

  Setup optional Ocean packages and configuration file(s).

  Equivalent to running `dwave install [--all]`, followed by an optional
  `dwave auth login [--oob]` and then by `dwave config create [--full]
  [--auto-token]`.

Options:
  -a, --install-all, --all  Install all non-open-source packages available and
                            accept licenses without prompting
  --auth                    Authorize Ocean to access Leap API on user's
                            behalf. Implies --auto-token during 'dwave config
                            create' and it's mutually exclusive with --full.
  --project TEXT            Leap project for which SAPI token is pulled.
                            Defaults to active project.
  --oob                     Same as '--auth', but using OAuth out-of-band
                            flow. Use when 'localhost' not available in your
                            browser.
  --full                    Configure non-essential options manually (such as
                            endpoint and solver).
  -v, --verbose             Increase output verbosity (additive, up to 4
                            times)  [default: 0]
  --help                    Show this message and exit.
```

We now also skip contrib package(s) install/prompt if all packages are already installed.

```
$ dwave setup --auth
Optionally install non-open-source packages and configure your environment.

All optional packages already installed.

Authorizing Leap access.

Valid token found, skipping authorization.

Creating the D-Wave configuration file.

Using the simplified configuration flow.
Try 'dwave config create --full' for more options.

Updating existing configuration file: /home/user/.config/dwave/dwave.conf
Available profiles: defaults, prod, test
Updating existing profile: defaults
Fetched SAPI token for project 'Project' (PROJ) from Leap API.
Configuration saved.
```


Close #591.