### PR TITLE
Fix use of some deprecated functions

### DIFF
--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -214,7 +214,7 @@ def datetime_to_timestamp(dt):
     Note: similar to `datetime.timestamp()` in Python 3.3+.
     """
 
-    epoch = datetime.utcfromtimestamp(0).replace(tzinfo=UTC)
+    epoch = datetime.fromtimestamp(0, tz=UTC)
     return (dt - epoch).total_seconds()
 
 

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -220,7 +220,7 @@ def datetime_to_timestamp(dt):
 
 def utcnow():
     """Returns tz-aware now in UTC."""
-    return datetime.utcnow().replace(tzinfo=UTC)
+    return datetime.now(tz=UTC)
 
 
 def epochnow() -> float:

--- a/tests/api/resources/test_problems.py
+++ b/tests/api/resources/test_problems.py
@@ -701,7 +701,7 @@ class NumpyParamsSerialization(unittest.TestCase):
 
     # basic scalar types we support for parameter values
     NUMPY_TYPES_AS_PYTHON = [
-        (numpy.bool_(1), True), (numpy.bool8(1), True),
+        (numpy.bool_(1), True),
         (numpy.byte(1), 1), (numpy.int8(1), 1),
         (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
         (numpy.short(1), 1), (numpy.int16(1), 1),

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -1079,7 +1079,7 @@ class TestSerialization(unittest.TestCase):
         return problems
 
     @parameterized.expand([
-        (numpy.bool_(1), True), (numpy.bool8(1), True),
+        (numpy.bool_(1), True),
         (numpy.byte(1), 1), (numpy.int8(1), 1),
         (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
         (numpy.short(1), 1), (numpy.int16(1), 1),

--- a/tests/test_mock_unstructured_submission.py
+++ b/tests/test_mock_unstructured_submission.py
@@ -418,7 +418,7 @@ class TestSerialization(unittest.TestCase):
         return _submit
 
     @parameterized.expand([
-        (numpy.bool_(1), True), (numpy.bool8(1), True),
+        (numpy.bool_(1), True),
         (numpy.byte(1), 1), (numpy.int8(1), 1),
         (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
         (numpy.short(1), 1), (numpy.int16(1), 1),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -182,7 +182,7 @@ class TestSimpleUtils(unittest.TestCase):
 class TestNumpyTypesEncoding(unittest.TestCase):
 
     NUMPY_SCALARS = [
-        (numpy.bool_(1), True), (numpy.bool8(1), True),
+        (numpy.bool_(1), True),
         (numpy.byte(1), 1), (numpy.int8(1), 1),
         (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
         (numpy.short(1), 1), (numpy.int16(1), 1),


### PR DESCRIPTION
- datetime functions deprecated in py312
- np.bool8 deprecated in numpy 1.24