### PR TITLE
Fix RtD docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 
 python:
   install:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx_rtd_theme
-reno[sphinx]==3.4.0
+reno[sphinx]~=4.0


### PR DESCRIPTION
Fix `reno` version traversal during RtD docs build (see error [here](https://readthedocs.com/projects/d-wave-systems-dwave-cloud-client/builds/2040024/)) by doing an [unshallow git clone](https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone) (instead of the default shallow).