### PR TITLE
Speed-up `User-Agent` construction

### DIFF
--- a/dwave/cloud/auth/flows.py
+++ b/dwave/cloud/auth/flows.py
@@ -32,7 +32,7 @@ from dwave.cloud.auth.creds import Credentials
 from dwave.cloud.auth.server import SingleRequestAppServer, RequestCaptureAndRedirectApp
 from dwave.cloud.config.models import ClientConfig
 from dwave.cloud.regions import resolve_endpoints
-from dwave.cloud.utils import pretty_argvalues
+from dwave.cloud.utils import pretty_argvalues, default_user_agent
 
 __all__ = ['AuthFlow', 'LeapAuthFlow', 'OAuthError']
 
@@ -95,6 +95,9 @@ class AuthFlow:
             # metadata set via kwargs
             authorization_endpoint=authorization_endpoint,
             token_endpoint=token_endpoint)
+
+        # set default headers (overwritten by ``session_config['headers']``)
+        self.session.headers.update({'User-Agent': default_user_agent()})
 
         if session_config is not None:
             self.update_session(session_config)

--- a/dwave/cloud/client/base.py
+++ b/dwave/cloud/client/base.py
@@ -72,7 +72,7 @@ from dwave.cloud.regions import get_regions, resolve_endpoints
 from dwave.cloud.upload import ChunkedData
 from dwave.cloud.events import dispatches_events
 from dwave.cloud.utils import (
-    PretimedHTTPAdapter, BaseUrlSession, user_agent,
+    PretimedHTTPAdapter, BaseUrlSession, default_user_agent,
     datetime_to_timestamp, utcnow, cached, retried, is_caused_by)
 
 __all__ = ['Client']
@@ -536,22 +536,6 @@ class Client(object):
         self._encode_problem_executor = \
             ThreadPoolExecutor(self._ENCODE_PROBLEM_THREAD_COUNT)
 
-    @cached_property
-    def _user_agent(self):
-        """User-Agent string for this client instance, as returned by
-        :meth:`~dwave.cloud.utils.user_agent`, computed on first access and
-        cached for the lifespan of the client.
-
-        Note:
-            The only tags that might change are platform tags, as returned by
-            ``dwave.common.platform.tags`` entry points, and `platform.platform()`
-            (like linux kernel version). Assuming OS/machine won't change during
-            client's lifespan, and typical platform tags defined via entry points
-            depend on process environments (which rarely change), it's pretty safe
-            to always use the per-instance cached user agent.
-        """
-        return user_agent(__packagename__, __version__)
-
     def create_session(self):
         """Create a new requests session based on client's (self) params.
 
@@ -572,7 +556,7 @@ class Client(object):
             timeout=self.config.request_timeout,
             max_retries=self.config.request_retry.to_urllib3_retry()))
 
-        session.headers.update({'User-Agent': self._user_agent})
+        session.headers.update({'User-Agent': default_user_agent()})
         if self.config.headers:
             session.headers.update(self.config.headers)
         if self.config.token:

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -423,12 +423,12 @@ def user_agent(name=None, version=None):
     def _interpreter():
         name = platform.python_implementation()
         version = platform.python_version()
-        bitness = platform.architecture()[0]
         if name == 'PyPy':
             version = '.'.join(map(str, sys.pypy_version_info[:3]))
         full_version = [version]
-        if bitness:
-            full_version.append(bitness)
+        is_64bits = sys.maxsize > 2**32
+        if is_64bits:
+            full_version.append('64bit')
         return name, "-".join(full_version)
 
     tags = []

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -39,6 +39,8 @@ import diskcache
 from importlib_metadata import entry_points
 from packaging.requirements import Requirement
 
+from dwave.cloud.package_info import __packagename__, __version__
+
 # Use numpy if available for fast decoding
 try:
     import numpy
@@ -468,6 +470,13 @@ def user_agent(name: Optional[str] = None,
         tags.extend(get_platform_tags())
 
     return ' '.join("{}/{}".format(name, version) for name, version in tags)
+
+
+# defined as a function rather than constant because env might change during runtime
+def default_user_agent() -> str:
+    """Default user agent string to be used consistently across client(s)."""
+    return user_agent(
+        name=__packagename__, version=__version__, include_platform_tags=False)
 
 
 class CLIError(Exception):

--- a/dwave/cloud/utils.py
+++ b/dwave/cloud/utils.py
@@ -417,8 +417,27 @@ def is_caused_by(exception, exception_types):
     return hasinstance(exception_chain(exception), exception_types)
 
 
-def user_agent(name=None, version=None):
-    """Return User-Agent ~ "name/version language/version interpreter/version os/version"."""
+def user_agent(name: Optional[str] = None,
+               version: Optional[str] = None,
+               *,
+               include_platform_tags: bool = True) -> str:
+    """Return User-Agent ~ "name/version language/version interpreter/version os/version".
+
+    Args:
+        name:
+            Package name, primary UA component name.
+        version:
+            Package version, primary UA component version.
+        include_platform_tags:
+            Look for, query and include externally-contributed platform tags
+            (via ``dwave.common.platform.tags`` entrypoint).
+            See :func:`dwave.cloud.utils.get_platform_tags`.
+
+    Return:
+        User-Agent string composed of "key/value" pairs (joined with a space
+        character), for following components: package, language, interpreter,
+        machine, system and platform.
+    """
 
     def _interpreter():
         name = platform.python_implementation()
@@ -445,7 +464,8 @@ def user_agent(name=None, version=None):
     ])
 
     # add platform-specific tags
-    tags.extend(get_platform_tags())
+    if include_platform_tags:
+        tags.extend(get_platform_tags())
 
     return ' '.join("{}/{}".format(name, version) for name, version in tags)
 

--- a/releasenotes/notes/use-consistent-user-agent-c2994b17a0f253ef.yaml
+++ b/releasenotes/notes/use-consistent-user-agent-c2994b17a0f253ef.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Use a consistent ``User-Agent`` value for all API and non-API requests made
+    by ``Client``, ``api.Client`` and ``auth.flow`` client.
+  - Speed-up ``User-Agent`` string construction significantly (10ms to 5us).

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,8 +36,8 @@ from dwave.cloud.utils import (
     active_qubits, generate_random_ising_problem,
     NumpyEncoder, coerce_numpy_to_python,
     default_text_input, utcnow, cached, retried, deprecated, aliasdict,
-    parse_loglevel, user_agent, hasinstance, exception_chain, is_caused_by,
-    get_distribution, PackageNotFoundError, VersionNotFoundError)
+    parse_loglevel, user_agent, default_user_agent, hasinstance, exception_chain,
+    is_caused_by, get_distribution, PackageNotFoundError, VersionNotFoundError)
 
 
 class TestSimpleUtils(unittest.TestCase):
@@ -175,6 +175,13 @@ class TestSimpleUtils(unittest.TestCase):
         required = [__packagename__, 'python', 'machine', 'system', 'platform']
         for key in required:
             self.assertIn(key, ua)
+
+    def test_default_user_agent(self):
+        from dwave.cloud.package_info import __packagename__, __version__
+        ua = default_user_agent()
+        ref = user_agent(
+            name=__packagename__, version=__version__, include_platform_tags=False)
+        self.assertEqual(ua, ref)
 
 
 # initially copied from dwave-hybrid/NumpyEncoder tests, but expanded to cover


### PR DESCRIPTION
Default UA we now use consistently across all clients (`base.Client`, `api.Client`, `auth.flow`) is now constructed in **under 5us instead of 11ms+** (on my machine).

Consequently, client construction is sped-up as well.