### PR TITLE
Upper-bound requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: |
             . env/bin/activate
             pip install -U pip
-            pip install -r requirements.txt -r tests/requirements.txt
+            pip install -U -r requirements.txt -r tests/requirements.txt
 
       - save_cache: &save-cache-env
           key: *env-cache-key
@@ -161,7 +161,7 @@ jobs:
           command: |
             env\Scripts\activate.ps1
             pip install -U pip
-            pip install -r requirements.txt -r tests\requirements.txt
+            pip install -U -r requirements.txt -r tests\requirements.txt
 
       - run:
           name: Install package
@@ -188,7 +188,7 @@ jobs:
 
       - run:
           name: Install docs requirements
-          command: env/bin/pip install -r docs/requirements.txt
+          command: env/bin/pip install -U -r docs/requirements.txt
 
       - run: *install-package
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-requests[socks]>=2.25
-urllib3>=1.26.0
+requests[socks]>=2.25,<3
+urllib3>=1.26.0,<3
 pydantic>=2,<3
-homebase>=1.0.0
-python-dateutil>=2.7
-click>=7
-plucky>=0.4.3
-diskcache>=5.2.1
+homebase>=1.0.0,<2
+python-dateutil>=2.7,<3
+click>=7,<9
+plucky>=0.4.3,<0.5
+diskcache>=5.2.1,<6
 packaging>=19
-werkzeug>=2.2
-typing-extensions>=4.5.0
+werkzeug>=2.2,<3
+typing-extensions>=4.5.0,<5
 authlib>=1.2,<2
 
 # bring in py312 semantics of importlib.metadata.entry_points()
@@ -24,4 +24,4 @@ numpy>=1.17.3
 dwave-networkx>=0.8.9
 
 # dev requirements
-reno==3.4.0
+reno~=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-requests[socks]>=2.18
+requests[socks]>=2.25
+urllib3>=1.26.0
 pydantic>=2,<3
 homebase>=1.0.0
 python-dateutil>=2.7

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ with open(package_info_path, encoding='utf-8') as f:
 python_requires = '>=3.8'
 
 # Package requirements, minimal pinning
-install_requires = ['requests[socks]>=2.18', 'pydantic>=2,<3', 'homebase>=1.0',
+install_requires = ['requests[socks]>=2.25,<3', 'urllib3>=1.26,<3',
+                    'pydantic>=2,<3', 'homebase>=1.0',
                     'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3',
                     'diskcache>=5.2.1', 'packaging>=19', 'werkzeug>=2.2',
                     'typing-extensions>=4.5.0', 'authlib>=1.2,<2',

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ python_requires = '>=3.8'
 
 # Package requirements, minimal pinning
 install_requires = ['requests[socks]>=2.25,<3', 'urllib3>=1.26,<3',
-                    'pydantic>=2,<3', 'homebase>=1.0',
-                    'click>=7.0', 'python-dateutil>=2.7', 'plucky>=0.4.3',
-                    'diskcache>=5.2.1', 'packaging>=19', 'werkzeug>=2.2',
-                    'typing-extensions>=4.5.0', 'authlib>=1.2,<2',
+                    'pydantic>=2,<3', 'homebase>=1.0,<2',
+                    'click>=7.0,<9', 'python-dateutil>=2.7,<3', 'plucky>=0.4.3,<0.5',
+                    'diskcache>=5.2.1,<6', 'packaging>=19', 'werkzeug>=2.2,<4',
+                    'typing-extensions>=4.5.0,<5', 'authlib>=1.2,<2',
                     'importlib_metadata>=5.0.0',    # can be dropped in py312+
                     ]
 


### PR DESCRIPTION
Preemptively set upper bounds on dependencies to prevent future breaks on older installed versions in the wild.

Also, fix lower bounds for requests and urllib3.