### PR TITLE
Delegate JSON response validation to content type validation

### DIFF
--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -439,15 +439,9 @@ class DWaveAPIClient:
         # failure. However, that is currently not the case. We need to work
         # around this until it's fixed.
 
-        # no error -> body is json
+        # no error -> content type verified by `VersionedAPISession ` @accepts
         # error -> body can be json or plain text error message
-        if response.ok:
-            try:
-                response.json()
-            except:
-                raise exceptions.ResourceBadResponseError("JSON response expected")
-
-        else:
+        if not response.ok:
             try:
                 msg = response.json()
                 error_msg = msg['error_msg']

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -60,7 +60,7 @@ class ResourceBase:
     client_class: DWaveAPIClient = DWaveAPIClient
 
     # endpoint path prefix (base path) specific to all methods on the resource
-    resource_path: str = None
+    resource_path: Optional[str] = None
 
     def __init__(self, client: Optional[DWaveAPIClient] = None, **config):
         if isinstance(client, DWaveAPIClient):


### PR DESCRIPTION
This generalization allows `dwave.cloud.api` client(s) to "accept" non-json responses, e.g. binary streams.