### PR TITLE
Fix ambiguous xrefs to reduce build warnings

### DIFF
--- a/docs/reference/resources.rst
+++ b/docs/reference/resources.rst
@@ -58,7 +58,6 @@ Methods
    Client.get_regions
    Client.get_solver
    Client.get_solvers
-   Client.solvers
    Client.is_solver_handled
    Client.retrieve_answer
    Client.close

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -393,7 +393,7 @@ class BaseUnstructuredSolver(BaseSolver):
                 Optional problem encoding and upload parameters.
 
         Returns:
-            :class:`concurrent.futures.Future`[str]:
+            :class:`concurrent.futures.Future`\ [str]:
                 Problem ID in a Future. Problem ID can be used to submit
                 problems by reference.
         """
@@ -554,19 +554,19 @@ class BQMSolver(BaseUnstructuredSolver):
         return self.sample_problem(bqm, label=label, **params)
 
     def upload_bqm(self, bqm):
-        """Upload the specified :term:`BQM` to SAPI, returning a Problem ID
+        r"""Upload the specified :term:`BQM` to SAPI, returning a Problem ID
         that can be used to submit the BQM to this solver (i.e. call the
-        `.sample_bqm` method).
+        :meth:`.sample_bqm` method).
 
         Args:
-            bqm (:class:`~dimod.BinaryQuadraticModel`/bytes-like/file-like):
+            bqm (:class:`~dimod.binary.BinaryQuadraticModel`\ /bytes-like/file-like):
                 A binary quadratic model given either as an in-memory
-                :class:`~dimod.BinaryQuadraticModel` object, or as raw data
+                :class:`~dimod.binary.BinaryQuadraticModel` object, or as raw data
                 (encoded serialized model) in either a file-like or a bytes-like
                 object.
 
         Returns:
-            :class:`concurrent.futures.Future`[str]:
+            :class:`concurrent.futures.Future`\ [str]:
                 Problem ID in a Future. Problem ID can be used to submit
                 problems by reference.
 
@@ -675,7 +675,7 @@ class DQMSolver(BaseUnstructuredSolver):
                 object.
 
         Returns:
-            :class:`concurrent.futures.Future`[str]:
+            :class:`concurrent.futures.Future`\ [str]:
                 Problem ID in a Future. Problem ID can be used to submit
                 problems by reference.
 
@@ -763,7 +763,7 @@ class CQMSolver(BaseUnstructuredSolver):
                 object.
 
         Returns:
-            :class:`concurrent.futures.Future`[str]:
+            :class:`concurrent.futures.Future`\ [str]:
                 Problem ID in a Future. Problem ID can be used to submit
                 problems by reference.
 
@@ -909,7 +909,7 @@ class NLSolver(BaseUnstructuredSolver):
                 like ``max_num_states``.
 
         Returns:
-            :class:`concurrent.futures.Future`[str]:
+            :class:`concurrent.futures.Future`\ [str]:
                 Problem ID in a Future. Problem ID can be used to submit
                 problems by reference.
 

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -556,7 +556,7 @@ class BQMSolver(BaseUnstructuredSolver):
     def upload_bqm(self, bqm):
         r"""Upload the specified :term:`BQM` to SAPI, returning a Problem ID
         that can be used to submit the BQM to this solver (i.e. call the
-        :meth:`.sample_bqm` method).
+        :meth:`~BQMSolver.sample_bqm` method).
 
         Args:
             bqm (:class:`~dimod.binary.BinaryQuadraticModel`\ /bytes-like/file-like):


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300), [dimod](https://github.com/dwavesystems/dimod/pull/1372), [dwave-system](https://github.com/dwavesystems/dwave-system/pull/524), and [dwave-hybrid](https://github.com/dwavesystems/dwave-hybrid/pull/294) PRs to reduce build warnings