### PR TITLE
Improve `@cached.ondisk` resilience to forking/high concurrency

### DIFF
--- a/dwave/cloud/config/loaders.py
+++ b/dwave/cloud/config/loaders.py
@@ -238,13 +238,19 @@ def get_default_configfile_path(**kwargs) -> str:
     return get_configfile_paths(**kwargs)[0]
 
 
-def get_cache_dir() -> str:
+def get_cache_dir(create: bool = False) -> str:
     """Return a directory path convenient for storing user-local,
     package-local and version-specific cache data.
     """
-    return homebase.user_cache_dir(
+    path = homebase.user_cache_dir(
         app_name=__packagename__, app_author=CONF_AUTHOR,
-        version=__version__, use_virtualenv=False, create=True)
+        version=__version__, use_virtualenv=False, create=False)
+
+    # avoid possible race condition on create (https://github.com/dwavesystems/homebase/issues/37)
+    if create:
+        os.makedirs(path, exist_ok=True)
+
+    return path
 
 
 def load_config_from_files(filenames=None):

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -381,7 +381,7 @@ class BaseUnstructuredSolver(BaseSolver):
         raise NotImplementedError
 
     def upload_problem(self, problem, **kwargs):
-        """Encode and upload the problem.
+        r"""Encode and upload the problem.
 
         Args:
             problem (model-like):
@@ -663,7 +663,7 @@ class DQMSolver(BaseUnstructuredSolver):
         return self.sample_problem(dqm, label=label, **params)
 
     def upload_dqm(self, dqm):
-        """Upload the specified :term:`DQM` to SAPI, returning a Problem ID
+        r"""Upload the specified :term:`DQM` to SAPI, returning a Problem ID
         that can be used to submit the DQM to this solver (i.e. call the
         `.sample_dqm` method).
 
@@ -751,7 +751,7 @@ class CQMSolver(BaseUnstructuredSolver):
         return self.sample_problem(cqm, label=label, **params)
 
     def upload_cqm(self, cqm):
-        """Upload the specified :term:`CQM` to SAPI, returning a Problem ID
+        r"""Upload the specified :term:`CQM` to SAPI, returning a Problem ID
         that can be used to submit the CQM to this solver (i.e. call the
         `.sample_cqm` method).
 
@@ -892,7 +892,7 @@ class NLSolver(BaseUnstructuredSolver):
                    model: typing.Union['dwave.optimization.Model', io.IOBase, bytes],
                    **upload_params,
                    ) -> concurrent.futures.Future:
-        """Upload the specified :term:`NL model` to SAPI, returning a Problem ID
+        r"""Upload the specified :term:`NL model` to SAPI, returning a Problem ID
         that can be used to submit the NL model to this solver (i.e. call the
         :meth:`.sample_nlm` method).
 

--- a/dwave/cloud/utils/decorators.py
+++ b/dwave/cloud/utils/decorators.py
@@ -30,7 +30,6 @@ from secrets import token_hex
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 from unittest import mock
 
-from dwave.cloud.config import get_cache_dir
 from dwave.cloud.utils.time import epochnow
 
 __all__ = ['aliasdict', 'cached', 'deprecated', 'retried']
@@ -284,6 +283,9 @@ class cached:
     @classmethod
     def ondisk(cls, **kwargs):
         """@cached backed by an on-disk sqlite3-based cache."""
+
+        # defer to break circular imports
+        from dwave.cloud.config import get_cache_dir
 
         directory = kwargs.pop('directory', get_cache_dir())
         compression_level = kwargs.pop('compression_level', 6)

--- a/releasenotes/notes/lazy-disk-cache-init-e400c535079a8aed.yaml
+++ b/releasenotes/notes/lazy-disk-cache-init-e400c535079a8aed.yaml
@@ -3,3 +3,10 @@ fixes:
   - |
     Defer SQLite connect in ``@cached.ondisk()`` until actually needed. Also,
     verify cache thread/process-safety and forking support.
+  - |
+    Fix ``get_cache_dir()`` to not create the cache directory by default. Creation
+    is now optional and controlled with ``create`` argument. This makes it consistent
+    with other config path functions.
+  - |
+    Fix possible race condition during cache directory create.
+    See `homebase#37 <https://github.com/dwavesystems/homebase/issues/37>`_.

--- a/releasenotes/notes/lazy-disk-cache-init-e400c535079a8aed.yaml
+++ b/releasenotes/notes/lazy-disk-cache-init-e400c535079a8aed.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Defer SQLite connect in ``@cached.ondisk()`` until actually needed. Also,
+    verify cache thread/process-safety and forking support.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -459,7 +459,7 @@ class TestConfigUtils(unittest.TestCase):
             parse_boolean('x')
 
     def test_cache_dir(self):
-        path = get_cache_dir()
+        path = get_cache_dir(create=True)
         self.assertTrue(os.path.isdir(path))
         self.assertIn(__packagename__, path)
         self.assertIn(__version__, path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -553,9 +553,11 @@ class TestCachedForking(unittest.TestCase):
         # than trying to kill the forked unittest suite after a forking test case.
         program = textwrap.dedent("""
             import os
+            import tempfile
             from dwave.cloud.utils.decorators import cached
 
-            @cached.ondisk()
+            # isolate cache to avoid https://github.com/grantjenks/python-diskcache/issues/325
+            @cached.ondisk(directory=tempfile.mkdtemp())
             def f():
                 return 42
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,11 @@ import copy
 import io
 import json
 import logging
+import os
+import sqlite3
+import subprocess
 import tempfile
+import textwrap
 import time
 import unittest
 import uuid
@@ -510,6 +514,39 @@ class TestCachedOnDiskDecorator(TestCachedCommon):
 
         f2 = self.cached(bucket='fixed')(f)
         self.assertEqual(f2(), 0)
+
+
+@unittest.skipUnless(hasattr(os, 'fork'), "os.fork() not available on this platform")
+class TestCachedForking(unittest.TestCase):
+
+    @unittest.skipUnless(sqlite3.threadsafety == 3,
+                         "sqlite3 is not compiled with serialized threading mode support")
+    def test_cache_connection_safety_post_forking(self):
+        # note: this convoluted subprocess call approach seems to be simpler
+        # than trying to kill the forked unittest suite after a forking test case.
+        program = textwrap.dedent("""
+            import os
+            from dwave.cloud.utils.decorators import cached
+
+            @cached.ondisk()
+            def f():
+                return 42
+
+            # make sure db connection is opened
+            f()
+
+            os.fork()
+
+            # make sure cache works in both parent and child
+            if f() != 42:
+                print("FAIL")
+        """)
+
+        run = subprocess.run(f"echo '{program}' | python", shell=True, capture_output=True)
+
+        self.assertEqual(run.returncode, 0)
+        self.assertEqual(run.stdout.strip(), b'')
+        self.assertEqual(run.stderr.strip(), b'')
 
 
 class TestRetriedDecorator(unittest.TestCase):


### PR DESCRIPTION
Test/improve forking/concurrency resilience from https://github.com/dwavesystems/dwave-cloud-client/issues/641.
Mitigate race condition from https://github.com/dwavesystems/homebase/issues/37.