### PR TITLE
Speed up imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
             . env/bin/activate
             pip install -r benchmarks/requirements.txt
             asv machine --yes
-            asv run -q
+            asv run -q HEAD^!
 
   build-dist:
     docker:

--- a/dwave/cloud/__init__.py
+++ b/dwave/cloud/__init__.py
@@ -16,6 +16,7 @@ import sys
 import logging
 import importlib
 import types
+import warnings
 
 from dwave.cloud.utils.logging import add_loglevel, configure_logging_from_env
 
@@ -50,7 +51,13 @@ def _alias_old_client_submodules():
         def __getattr__(self, name):
             modname = self.__name__
             if name == 'Client':
-                mod = importlib.import_module('dwave.cloud.client.{}'.format(modname))
+                warnings.warn(
+                    f"Importing 'Client' from 'dwave.cloud.{modname}' has been "
+                    f"deprecated and will be removed in dwave-cloud-client 0.14. "
+                    f"Import 'Client' directly from 'dwave.cloud.client.{modname}'.",
+                    DeprecationWarning, stacklevel=2)
+
+                mod = importlib.import_module(f'dwave.cloud.client.{modname}')
                 return getattr(mod, 'Client')
 
             raise AttributeError(f"module '{self.__name__}' has no attribute '{name}'")
@@ -58,4 +65,5 @@ def _alias_old_client_submodules():
     for name in ('qpu', 'sw', 'hybrid'):
         globals()[name] = sys.modules[f'dwave.cloud.{name}'] = _submod(name)
 
+# TODO: remove in 0.14.0
 _alias_old_client_submodules()

--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -16,18 +16,20 @@ from __future__ import annotations
 
 import logging
 from collections import deque, namedtuple
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 import requests
 import urllib3
 from packaging.specifiers import SpecifierSet
 from werkzeug.http import parse_options_header, dump_options_header
 
+import dwave.cloud.config   # don't use `from` to break circular import (config <> api.constants)
 from dwave.cloud.api import constants, exceptions
-from dwave.cloud.config import load_config, validate_config_v1
-from dwave.cloud.config.models import ClientConfig
 from dwave.cloud.utils.exception import is_caused_by
 from dwave.cloud.utils.http import PretimedHTTPAdapter, BaseUrlSession, default_user_agent
+
+if TYPE_CHECKING:
+    from dwave.cloud.config.models import ClientConfig
 
 __all__ = ['DWaveAPIClient', 'SolverAPIClient', 'MetadataAPIClient', 'LeapAPIClient']
 
@@ -326,8 +328,8 @@ class DWaveAPIClient:
         logger.trace(f"{cls.__name__}.from_config_file("
                      f"config_file={config_file!r}, profile={profile!r}, **{kwargs!r})")
 
-        options = load_config(config_file=config_file, profile=profile, **kwargs)
-        config = validate_config_v1(options)
+        options = dwave.cloud.config.load_config(config_file=config_file, profile=profile, **kwargs)
+        config = dwave.cloud.config.validate_config_v1(options)
         return cls.from_config_model(config)
 
     @classmethod
@@ -346,7 +348,7 @@ class DWaveAPIClient:
         """
         logger.trace(f"{cls.__name__}.from_config(config={config!r}, **{kwargs!r}")
 
-        if isinstance(config, ClientConfig):
+        if isinstance(config, dwave.cloud.config.ClientConfig):
             return cls.from_config_model(config, **kwargs)
 
         kwargs['config_file'] = config

--- a/dwave/cloud/api/resources.py
+++ b/dwave/cloud/api/resources.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import io
 import json
-from typing import List, Union, Optional, Callable, get_type_hints
+from typing import List, Union, Optional, Callable, get_type_hints, TYPE_CHECKING
 from functools import wraps
 
 from pydantic import TypeAdapter
@@ -22,8 +24,10 @@ from pydantic import TypeAdapter
 from dwave.cloud.api.client import (
     DWaveAPIClient, SolverAPIClient, MetadataAPIClient, LeapAPIClient)
 from dwave.cloud.api import constants, models
-from dwave.cloud.config.models import ClientConfig
 from dwave.cloud.utils.coders import NumpyEncoder
+
+if TYPE_CHECKING:
+    from dwave.cloud.config.models import ClientConfig
 
 __all__ = ['Solvers', 'Problems', 'Regions']
 

--- a/dwave/cloud/auth/flows.py
+++ b/dwave/cloud/auth/flows.py
@@ -18,7 +18,7 @@ import logging
 import time
 import webbrowser
 from operator import sub
-from typing import Any, Callable, Dict, Optional, Union, Sequence, Literal
+from typing import Any, Callable, Dict, Optional, Union, Sequence, Literal, TYPE_CHECKING
 from urllib.parse import urljoin
 
 import click
@@ -31,10 +31,12 @@ from authlib.common.urls import add_params_to_uri
 from dwave.cloud.auth.config import OCEAN_SDK_CLIENT_ID, OCEAN_SDK_SCOPES
 from dwave.cloud.auth.creds import Credentials
 from dwave.cloud.auth.server import SingleRequestAppServer, RequestCaptureAndRedirectApp
-from dwave.cloud.config.models import ClientConfig
 from dwave.cloud.regions import resolve_endpoints
 from dwave.cloud.utils.http import default_user_agent
 from dwave.cloud.utils.logging import pretty_argvalues
+
+if TYPE_CHECKING:
+    from dwave.cloud.config.models import ClientConfig
 
 __all__ = ['AuthFlow', 'LeapAuthFlow', 'OAuthError']
 

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -27,9 +27,8 @@ from typing import Callable, Dict, Optional, Tuple
 import click
 import requests.exceptions
 
-import dwave.cloud
-from dwave.cloud import Client
 from dwave.cloud import api
+from dwave.cloud.client import Client
 from dwave.cloud.solver import StructuredSolver, BaseUnstructuredSolver
 from dwave.cloud.utils.cli import default_text_input, strtrunc, CLIError
 from dwave.cloud.utils.dist import (

--- a/dwave/cloud/utils/decorators.py
+++ b/dwave/cloud/utils/decorators.py
@@ -28,7 +28,6 @@ import warnings
 from functools import wraps
 from secrets import token_hex
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
-from unittest import mock
 
 from dwave.cloud.utils.time import epochnow
 
@@ -330,6 +329,10 @@ class cached:
         """
 
         def start(self):
+            # lazy import: cached.disabled is rarely used, yet mock import
+            # adds 50ms to root package import
+            from unittest import mock
+
             self.patcher = mock.patch.object(cached, '_disabled', True)
             self.patcher.start()
 

--- a/releasenotes/notes/speed-up-imports-d5012ac8751037b5.yaml
+++ b/releasenotes/notes/speed-up-imports-d5012ac8751037b5.yaml
@@ -12,3 +12,10 @@ features:
 
     The main benefit of such lazy imports is import performance, as "heavy"
     symbols are only imported when explicitly needed/asked for.
+deprecations:
+  - |
+    Shorthand import paths for specialized Clients (for ``qpu``, ``sw`` and
+    ``hybrid``) are deprecated in ``dwave-cloud-client==0.12.2`` and will be
+    removed in ``dwave-cloud-client==0.14.0``. Instead, use the full import
+    path, e.g. ``from dwave.cloud.client.qpu import Client``, instead of
+    ``from dwave.cloud.qpu import Client``.

--- a/releasenotes/notes/speed-up-imports-d5012ac8751037b5.yaml
+++ b/releasenotes/notes/speed-up-imports-d5012ac8751037b5.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Lazily import ``Client``/``Solver``/``Future`` in the top-level namespace,
+    ``dwave.cloud``. Direct imports are preferred, e.g.
+    ``from dwave.cloud.client import Client``, but the widely-used way
+    (``from dwave.cloud import Client``) is still supported for backwards
+    compatibility.
+
+    Similarly we now lazily import old namespaces with client type as submodule,
+    e.g. ``dwave.cloud.qpu``.
+
+    The main benefit of such lazy imports is import performance, as "heavy"
+    symbols are only imported when explicitly needed/asked for.

--- a/releasenotes/notes/speed-up-imports-d5012ac8751037b5.yaml
+++ b/releasenotes/notes/speed-up-imports-d5012ac8751037b5.yaml
@@ -12,6 +12,8 @@ features:
 
     The main benefit of such lazy imports is import performance, as "heavy"
     symbols are only imported when explicitly needed/asked for.
+  - |
+    Speed-up imports by slightly decoupling submodules.
 deprecations:
   - |
     Shorthand import paths for specialized Clients (for ``qpu``, ``sw`` and

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ import os
 import warnings
 
 from dwave.cloud.config import load_config
-from dwave.cloud.exceptions import CanceledFutureError, ConfigFileError
+from dwave.cloud.exceptions import ConfigFileError
 
 
 # try to load client config needed for live tests on SAPI web service

--- a/tests/api/test_api_clients.py
+++ b/tests/api/test_api_clients.py
@@ -112,7 +112,7 @@ class TestConfig(unittest.TestCase):
         # `load_config` is already tested thoroughly in `tests.test_config`,
         # so it's ok to just mock it here
         config = dict(endpoint='https://test.com/path/')
-        with unittest.mock.patch("dwave.cloud.api.client.load_config",
+        with unittest.mock.patch("dwave.cloud.config.load_config",
                                  lambda *a, **kw: config):
             with DWaveAPIClient.from_config_file() as client:
                 self.assertEqual(client.session.base_url, config['endpoint'])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,7 @@ Tests the ability to connect to the SAPI server with the `dwave.cloud.qpu.Client
 test_mock_solver_loading.py duplicates some of these tests against a mock server.
 """
 
+import importlib
 import json
 import time
 import unittest
@@ -619,6 +620,15 @@ class ClientConstruction(unittest.TestCase):
             with dwave.cloud.Client.from_config(**retry_kwargs) as client:
                 retry = client.session.get_adapter('https://').max_retries
                 self._verify_retry_config(retry, retry_kwargs)
+
+
+class VerifyLazyClientImport(unittest.TestCase):
+
+    def test_client_available(self):
+        import dwave.cloud
+        import dwave.cloud.client
+
+        self.assertEqual(dwave.cloud.client.Client, dwave.cloud.Client)
 
 
 @mock.patch("dwave.cloud.regions.get_regions", get_default_regions)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -630,6 +630,12 @@ class VerifyLazyClientImport(unittest.TestCase):
 
         self.assertEqual(dwave.cloud.client.Client, dwave.cloud.Client)
 
+    @parameterized.expand([("qpu", ), ("sw", ), ("hybrid", )])
+    def test_deprecation(self, name):
+        with self.assertWarns(DeprecationWarning):
+            mod = importlib.import_module(f'dwave.cloud.{name}')
+            self.assertTrue(issubclass(getattr(mod, 'Client'), Client))
+
 
 @mock.patch("dwave.cloud.regions.get_regions", get_default_regions)
 class ClientConfigIntegration(unittest.TestCase):


### PR DESCRIPTION
Top-level namespace import is 20x faster; api and config imports around 30% faster; `dwave.cloud.Client` as before.