### PR TITLE
Implement response cache control

### DIFF
--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -366,6 +366,8 @@ class CachingSession(VersionedAPISession):
         # update cache from response according to cache-control
         # returns: updated?
 
+        # etag and cache-control are present in 304 if they're in 200 response
+        # see: https://datatracker.ietf.org/doc/html/rfc9110#name-304-not-modified
         etag = response.headers.get('ETag')
         cache_control = response.headers.get('Cache-Control')
 

--- a/dwave/cloud/api/client.py
+++ b/dwave/cloud/api/client.py
@@ -285,7 +285,7 @@ class CachingSession(VersionedAPISession):
 
     class CacheConfig(TypedDict, total=False):
         enabled: bool
-        maxage: float
+        maxage: int
         store: Union[Mapping, Callable[[], Mapping]]
 
     # default cache config
@@ -315,7 +315,10 @@ class CachingSession(VersionedAPISession):
             logger.debug("[%s] cache disabled.", type(self).__name__)
             return
 
-        self._maxage = config['maxage']
+        if not isinstance(_maxage := config.get('maxage'), int) or _maxage < 0:
+            raise ValueError("A non-negative integer required for 'maxage'.")
+        self._maxage = _maxage
+
         self._store = config['store']
         if callable(self._store):
             self._store = self._store()

--- a/dwave/cloud/client/base.py
+++ b/dwave/cloud/client/base.py
@@ -343,7 +343,7 @@ class Client(object):
     # Downloaded solver definition cache config
     _DEFAULT_SOLVERS_CACHE_CONFIG = dict(
         enabled=True,
-        maxage=900,     # 15 min heuristic maxage (TODO: API cache-control to override it)
+        maxage=3600,    # 1 hour heuristic maxage (cache-control in response overrides it)
     )
 
     # Downloaded region metadata cache maxage [sec]

--- a/releasenotes/notes/respect-cache-control-in-api-response-27dbd1a7f300648d.yaml
+++ b/releasenotes/notes/respect-cache-control-in-api-response-27dbd1a7f300648d.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Parse ``Cache-Control`` header field if present in API response, and use it
+    to guide local caching policy.
+
+    This means ``dwave.cloud.api.DWaveAPIClient`` and ``dwave.cloud.api.resource``
+    classes now respect origin server response caching policy.
+    See `#646 <https://github.com/dwavesystems/dwave-cloud-client/issues/646>`_.


### PR DESCRIPTION
Close #646.

Until `Cache-Control` header is added to SAPI responses, we cache heuristically** for 1 hour.

** since we can't actually determine [heuristic freshness](https://www.rfc-editor.org/rfc/rfc9111#name-calculating-heuristic-fresh) as neither `Last-Modified` or `Expires` are present in SAPI responses, we default to a reasonable period for solver metadata.