### PR TITLE
Enabled QPU problem data compression on upload

### DIFF
--- a/dwave/cloud/config/models.py
+++ b/dwave/cloud/config/models.py
@@ -163,6 +163,7 @@ class ClientConfig(BaseModel, GetterMixin):
     # specific connection options
     permissive_ssl: Optional[bool] = False
     connection_close: Optional[bool] = False
+    compress_qpu_problem_data: Optional[bool] = True
 
     # api request retry params
     request_retry: Optional[RequestRetryConfig] = RequestRetryConfig()
@@ -312,6 +313,7 @@ _V1_CONFIG_DEFAULTS = {
     'request_timeout': 60,
     'polling_timeout': None,
     'connection_close': False,
+    'compress_qpu_problem_data': True,
     'headers': None,
     'client_cert': None,
     'client_cert_key': None,

--- a/releasenotes/notes/add-compress-qpu-problem-data-option-86e708d10f80477a.yaml
+++ b/releasenotes/notes/add-compress-qpu-problem-data-option-86e708d10f80477a.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Enable QPU problem data compression on upload using ``deflate`` content
+    encoding.
+
+    Compression is controlled with a new config option, ``compress_qpu_problem_data``,
+    defaulting to true, and it can be turned off either in config file or via
+    ``Client()`` kwarg.


### PR DESCRIPTION
Controlled with `compress_qpu_problem_data` config option.

Close #622.

Follow-up:
- [ ] https://github.com/dwavesystems/dwave-cloud-client/issues/654
- [ ] https://github.com/dwavesystems/dwave-cloud-client/issues/653