### PR TITLE
Fix slow sapi requests due to logging

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import orjson
 import subprocess
 
@@ -32,6 +33,7 @@ from dwave.cloud.solver import StructuredSolver, BQMSolver, CQMSolver, DQMSolver
 from dwave.cloud.regions import resolve_endpoints, get_regions
 from dwave.cloud.testing import isolated_environ, mocks
 from dwave.cloud.utils.qubo import generate_random_ising_problem
+from dwave.cloud.utils.logging import get_caller_name
 
 
 # note: looks like timeraw benchmarks can't be parameterized
@@ -259,3 +261,13 @@ class JSONResponseDecode:
     def time_manual_model_from_python_orjson(self):
         solvers = orjson.loads(requests.get('http://mock').content)
         [SolverConfiguration.model_validate(solver) for solver in solvers]
+
+
+class InspectStack:
+    version = "1"
+
+    def time_caller_from_stack(self):
+        inspect.stack()[0].function
+
+    def time_fast_caller(self):
+        get_caller_name()

--- a/dwave/cloud/client/base.py
+++ b/dwave/cloud/client/base.py
@@ -40,7 +40,6 @@ import time
 import copy
 import queue
 import logging
-import inspect
 import warnings
 import operator
 import threading
@@ -74,10 +73,11 @@ from dwave.cloud.concurrency import PriorityThreadPoolExecutor
 from dwave.cloud.regions import get_regions, resolve_endpoints
 from dwave.cloud.upload import ChunkedData
 from dwave.cloud.events import dispatches_events
-from dwave.cloud.utils.http import PretimedHTTPAdapter, BaseUrlSession, default_user_agent
-from dwave.cloud.utils.time import datetime_to_timestamp, utcnow
-from dwave.cloud.utils.decorators import cached, retried
+from dwave.cloud.utils.decorators import retried
 from dwave.cloud.utils.exception import is_caused_by
+from dwave.cloud.utils.http import PretimedHTTPAdapter, BaseUrlSession, default_user_agent
+from dwave.cloud.utils.logging import get_caller_name
+from dwave.cloud.utils.time import datetime_to_timestamp, utcnow
 
 __all__ = ['Client']
 
@@ -1782,9 +1782,10 @@ class Client(object):
             :class:`~dwave.cloud.exceptions.RequestTimeout`.
         """
 
-        caller = inspect.stack()[1].function
-        verb = meth.__name__
-        logger.trace("[%s] request: session.%s(*%r, **%r)", caller, verb, args, kwargs)
+        caller = get_caller_name()
+        if logger.isEnabledFor(logging.TRACE):
+            logger.trace("[%s] request: session.%s(*%r, **%r)",
+                         caller, meth.__name__, args, kwargs)
 
         # execute request
         try:

--- a/dwave/cloud/utils/logging.py
+++ b/dwave/cloud/utils/logging.py
@@ -281,3 +281,12 @@ def fast_stack(max_depth: typing.Optional[int] = None) -> typing.List[inspect.Fr
             )
 
     return list(itertools.islice(frame_infos(inspect.currentframe()), max_depth))
+
+
+def get_caller_name(depth: int = 0) -> str:
+    """Return caller function name (for `depth=0`), or nth ancestor name (`depth>0`).
+    """
+    if depth < 0:
+        raise ValueError("non-negative integer required for 'depth'")
+
+    return fast_stack(max_depth=depth + 2)[depth + 1].function

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,7 +47,7 @@ from dwave.cloud.utils.exception import hasinstance, exception_chain, is_caused_
 from dwave.cloud.utils.http import user_agent, default_user_agent, platform_tags
 from dwave.cloud.utils.logging import (
     FilteredSecretsFormatter, configure_logging, parse_loglevel,
-    fast_stack)
+    fast_stack, get_caller_name)
 from dwave.cloud.utils.qubo import (
     uniform_iterator, uniform_get,
     active_qubits, generate_random_ising_problem)
@@ -1142,6 +1142,10 @@ class TestLoggingHelpers(unittest.TestCase):
 
     def test_max_depth(self):
         self.assertEqual(len(fast_stack(max_depth=3)), 3)
+
+    def test_get_caller_name(self):
+        self.assertEqual(get_caller_name(), inspect.stack()[0].function)
+        self.assertEqual(get_caller_name(1), inspect.stack()[1].function)
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import copy
+import inspect
 import io
 import json
 import logging
@@ -45,7 +46,8 @@ from dwave.cloud.utils.dist import (
 from dwave.cloud.utils.exception import hasinstance, exception_chain, is_caused_by
 from dwave.cloud.utils.http import user_agent, default_user_agent, platform_tags
 from dwave.cloud.utils.logging import (
-    FilteredSecretsFormatter, configure_logging, parse_loglevel)
+    FilteredSecretsFormatter, configure_logging, parse_loglevel,
+    fast_stack)
 from dwave.cloud.utils.qubo import (
     uniform_iterator, uniform_get,
     active_qubits, generate_random_ising_problem)
@@ -1121,6 +1123,25 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(debug), 2)
         self.assertEqual(debug[0].get('message'), 'debug')
         self.assertEqual(debug[1].get('message'), 'error')
+
+
+class TestLoggingHelpers(unittest.TestCase):
+
+    def test_fast_stack(self):
+        def f():
+            return inspect.stack()
+
+        def g():
+            return fast_stack()
+
+        stack = f()
+        fast = g()
+
+        self.assertEqual(len(stack), len(fast))
+        self.assertTrue(all(s.filename == f.filename for s,f in zip(stack,fast)))
+
+    def test_max_depth(self):
+        self.assertEqual(len(fast_stack(max_depth=3)), 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #658.

`get_caller_name()` is 200x faster than `inspect.stack()[1].function`.