### PR TITLE
Short-circuit event dispatch

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -29,6 +29,7 @@ from dwave.cloud.client import Client
 from dwave.cloud.api.models import SolverConfiguration
 from dwave.cloud.coders import encode_problem_as_qp
 from dwave.cloud.config import ClientConfig
+from dwave.cloud.events import dispatches_events
 from dwave.cloud.solver import StructuredSolver, BQMSolver, CQMSolver, DQMSolver, NLSolver
 from dwave.cloud.regions import resolve_endpoints, get_regions
 from dwave.cloud.testing import isolated_environ, mocks
@@ -271,3 +272,15 @@ class InspectStack:
 
     def time_fast_caller(self):
         get_caller_name()
+
+
+class EventDispatch:
+    version = "1"
+
+    # create an event-dispatch decorated functions with a non-empty signature
+    @dispatches_events('sample')
+    def dispatch(self, a, b, c=1, d=2, **kwargs):
+        return True
+
+    def time_null_event_dispatch(self):
+        self.dispatch(1, 2, d=1, e=2)

--- a/dwave/cloud/events.py
+++ b/dwave/cloud/events.py
@@ -65,6 +65,12 @@ def add_handler(name, handler):
     _client_event_hooks_registry[name].append(handler)
 
 
+def has_handler(name: str) -> bool:
+    """Check if event ``name`` has a handler registered."""
+
+    return len(_client_event_hooks_registry.get(name)) > 0
+
+
 def dispatch_event(name, *args, **kwargs):
     """Call the complete chain of event handlers attached to event `name`."""
 
@@ -97,6 +103,11 @@ class dispatches_events:
 
         @wraps(fn)
         def wrapped(*pargs, **kwargs):
+            if not (has_handler(self.before_eventname) or
+                    has_handler(self.after_eventname)):
+                # skip dispatch altogether
+                return fn(*pargs, **kwargs)
+
             sig = inspect.signature(fn)
             bound = sig.bind(*pargs, **kwargs)
             bound.apply_defaults()

--- a/releasenotes/notes/event-dispatch-shortcircuiting-d4503e58857c6667.yaml
+++ b/releasenotes/notes/event-dispatch-shortcircuiting-d4503e58857c6667.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Speed-up function calls that dispatch events by short-circuiting the
+    dispatch in case no event handlers are registered.


### PR DESCRIPTION
`100 us -> 3 us` for function calls that dispatch events, in the nominal case when no event handlers are registered. Currently we only register event handlers in `dwave-inspector`.