### PR TITLE
Speed up qp problem encoding

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -21,6 +21,7 @@ from functools import partial
 from pathlib import Path
 from typing import List
 
+import dimod
 import requests
 import requests_mock
 from pydantic import TypeAdapter
@@ -146,15 +147,25 @@ class ProblemEncoding:
     def setup(self, key):
         self.solver = StructuredSolver(client=None, data=InitQPUSolver.generators[key]())
         self.problem = generate_random_ising_problem(self.solver)
+        self.bqm = dimod.BQM.from_ising(*self.problem)
 
     def time_encode_qp(self, key):
         encode_problem_as_qp(self.solver, *self.problem)
 
+    def time_encode_qp_from_bqm(self, key):
+        encode_problem_as_qp(self.solver, self.bqm.linear, self.bqm.quadratic)
+
     def time_active_qubits(self, key):
         active_qubits(*self.problem)
 
+    def time_active_qubits_from_bqm(self, key):
+        active_qubits(self.bqm.linear, self.bqm.quadratic)
+
     def time_check_problem(self, key):
         self.solver.check_problem(*self.problem)
+
+    def time_check_problem_from_bqm(self, key):
+        self.solver.check_problem(self.bqm.linear, self.bqm.quadratic)
 
 
 # requires internet access

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -155,6 +155,9 @@ class ProblemEncoding:
     def time_encode_qp_from_bqm(self, key):
         encode_problem_as_qp(self.solver, self.bqm.linear, self.bqm.quadratic)
 
+    def time_encode_qp_from_bqm_to_dict(self, key):
+        encode_problem_as_qp(self.solver, dict(self.bqm.linear), dict(self.bqm.quadratic))
+
     def time_active_qubits(self, key):
         active_qubits(*self.problem)
 

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -32,7 +32,7 @@ from dwave.cloud.config import ClientConfig
 from dwave.cloud.solver import StructuredSolver, BQMSolver, CQMSolver, DQMSolver, NLSolver
 from dwave.cloud.regions import resolve_endpoints, get_regions
 from dwave.cloud.testing import isolated_environ, mocks
-from dwave.cloud.utils.qubo import generate_random_ising_problem
+from dwave.cloud.utils.qubo import generate_random_ising_problem, active_qubits
 from dwave.cloud.utils.logging import get_caller_name
 
 
@@ -149,6 +149,12 @@ class ProblemEncoding:
 
     def time_encode_qp(self, key):
         encode_problem_as_qp(self.solver, *self.problem)
+
+    def time_active_qubits(self, key):
+        active_qubits(*self.problem)
+
+    def time_check_problem(self, key):
+        self.solver.check_problem(*self.problem)
 
 
 # requires internet access

--- a/dwave/cloud/coders.py
+++ b/dwave/cloud/coders.py
@@ -14,7 +14,7 @@
 
 import struct
 import base64
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Sequence, Tuple, Union
 
 try:
     # note: TypedDict is available in py38+, but NotRequired only in py311+
@@ -73,6 +73,10 @@ def encode_problem_as_qp(solver: 'dwave.cloud.solver.StructuredSolver',
     Returns:
         Encoded submission dictionary.
     """
+    # convert legacy format (list) to dict for performance
+    if isinstance(linear, Sequence):
+        linear = dict(enumerate(linear))
+
     active = active_qubits(linear, quadratic)
 
     # Encode linear terms. The coefficients of the linear terms of the objective
@@ -82,7 +86,7 @@ def encode_problem_as_qp(solver: 'dwave.cloud.solver.StructuredSolver',
     # specified by the server.
     # Note: only active qubits are coded with double, inactive with NaN
     nan = float('nan')
-    lin = [uniform_get(linear, qubit, 0 if qubit in active else nan)
+    lin = [linear.get(qubit, 0 if qubit in active else nan)
            for qubit in solver._encoding_qubits]
 
     lin = base64.b64encode(struct.pack('<' + ('d' * len(lin)), *lin))

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -1177,7 +1177,11 @@ class StructuredSolver(BaseSolver):
         else:
             raise TypeError("unknown/unsupported vartype")
 
-        return self._sample(problem_type, bqm.linear, bqm.quadratic, bqm.offset,
+        # convert to dicts once, to save multiple conversions later on
+        linear = dict(bqm.linear)
+        quadratic = dict(bqm.quadratic)
+
+        return self._sample(problem_type, linear, quadratic, bqm.offset,
                             params, label=label, undirected_biases=True)
 
     @dispatches_events('sample')

--- a/dwave/cloud/utils/qubo.py
+++ b/dwave/cloud/utils/qubo.py
@@ -92,9 +92,11 @@ def active_qubits(linear: Union[Mapping, Sequence],
             Active qubits' indices.
     """
 
-    active = {idx for idx, bias in uniform_iterator(linear)}
-    for edge, _ in quadratic.items():
-        active.update(edge)
+    if isinstance(linear, Sequence):
+        active = set(range(len(linear)))
+    else:
+        active = set(linear)
+    active.update(*quadratic)
     return active
 
 

--- a/releasenotes/notes/speed-up-qp-encoding-f8ae1d86fa1dfde2.yaml
+++ b/releasenotes/notes/speed-up-qp-encoding-f8ae1d86fa1dfde2.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    Speed-up ``dwave.cloud.utils.qubo.active_qubits`` utility function by ~50%.
+    Speed-up ``dwave.cloud.utils.qubo.active_qubits`` utility function by ~50%,
+    and ``dwave.cloud.coders.encode_problem_as_qp`` by 20-30%.

--- a/releasenotes/notes/speed-up-qp-encoding-f8ae1d86fa1dfde2.yaml
+++ b/releasenotes/notes/speed-up-qp-encoding-f8ae1d86fa1dfde2.yaml
@@ -3,3 +3,6 @@ features:
   - |
     Speed-up ``dwave.cloud.utils.qubo.active_qubits`` utility function by ~50%,
     and ``dwave.cloud.coders.encode_problem_as_qp`` by 20-30%.
+  - |
+    Speed-up QPU problem sampling when problem submitted as BQM by 40%. For best
+    performance, keep linear and quadratic biases in ``dict``s.

--- a/releasenotes/notes/speed-up-qp-encoding-f8ae1d86fa1dfde2.yaml
+++ b/releasenotes/notes/speed-up-qp-encoding-f8ae1d86fa1dfde2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Speed-up ``dwave.cloud.utils.qubo.active_qubits`` utility function by ~50%.


### PR DESCRIPTION
ASV benchmarks on my machine:
- `active_qubits()`: `34 ms -> 22 ms`
- `active_qubits()` on BQM: `156 ms -> 121ms`
- `encode_problem_as_qp()`: `103 ms -> 75 ms`
- `encode_problem_as_qp()` on BQM: `650 ms -> 560 ms` and then ` -> 400 ms` when converted to `dict` upfront