### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
         type: string
       xcode:
         type: string
-        default: "14.2.0"
+        default: "16.0.0"
 
     macos:
       xcode: << parameters.xcode >>
@@ -325,7 +325,7 @@ workflows:
           context: &ctx-build "ocean-build"
           matrix:
             parameters:
-              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0rc3"]
+              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
               dimod-numpy-version: ["", "dimod~=0.9.0 numpy~=1.23.0", "dimod~=0.10.0", "dimod~=0.11.0", "dimod~=0.12.0"]
             exclude:
               # dimod < 0.10 not supported on py310+
@@ -335,7 +335,7 @@ workflows:
                 dimod-numpy-version: "dimod~=0.9.0 numpy~=1.23.0"
               - python-version: "3.12"
                 dimod-numpy-version: "dimod~=0.9.0 numpy~=1.23.0"
-              - python-version: "3.13.0rc3"
+              - python-version: "3.13"
                 dimod-numpy-version: "dimod~=0.9.0 numpy~=1.23.0"
               # dimod < 0.12 not supported on py311+
               - python-version: "3.11"
@@ -346,9 +346,9 @@ workflows:
                 dimod-numpy-version: "dimod~=0.10.0"
               - python-version: "3.12"
                 dimod-numpy-version: "dimod~=0.11.0"
-              - python-version: "3.13.0rc3"
+              - python-version: "3.13"
                 dimod-numpy-version: "dimod~=0.10.0"
-              - python-version: "3.13.0rc3"
+              - python-version: "3.13"
                 dimod-numpy-version: "dimod~=0.11.0"
 
       - test-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
 
   test-docs:
     docker:
-      - image: cimg/python:3.11
+      - image: python:3.12
 
     steps:
       - checkout
@@ -260,7 +260,7 @@ jobs:
 
   test-asv:
     docker:
-      - image: cimg/python:3.11
+      - image: python:3.12
 
     steps:
       - checkout
@@ -276,7 +276,7 @@ jobs:
 
   build-dist:
     docker:
-      - image: cimg/python:3.11
+      - image: python:3.12
 
     steps:
       - checkout
@@ -302,7 +302,7 @@ jobs:
 
   pypi-deploy:
     docker:
-      - image: cimg/python:3.11
+      - image: python:3.12
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,13 +147,20 @@ jobs:
           name: Install python and create virtualenv
           shell: bash -eo pipefail
           command: |
-            # resolve python MAJOR.MINOR version to latest MAJOR.MINOR.PATCH version available on NuGet
+            # de-normalize a pre-release version, because why would microsoft follow pep-440?
+            version=$(sed -E 's/([[:digit:]])([[:alpha:]])/\1-\2/' \<<<"<< parameters.python-version >>")
+
+            # resolve python MAJOR.MINOR[.PATCH[-PRERELEASE]] version to the latest
+            # MAJOR.MINOR.PATCH version available on NuGet (ignoring the actual pre-release segment)
+            # note: we rely on versions retrieved being sorted semantically!
+            # (so '3.13' might resolve to '3.13.0rc3' before final release, and to '3.13.0' afterwards)
             full_version=$(
-              curl -s 'https://azuresearch-usnc.nuget.org/query?q=python' \
+              curl -s 'https://azuresearch-usnc.nuget.org/query?q=python&prerelease=true' \
               | jq -r '.data[] | select(.id == "python") .versions[] | .version' \
-              | awk -F. -v ver='<< parameters.python-version >>' \
-                  'index($0, ver".") == 1 && $3 >= m { m = $3; v = $0 } END { print v }'
+              | awk -F'[.-]' -v ver="$version" \
+                  'index($0, ver) == 1 && $3 >= m { m = $3; v = $0 } END { print v }'
             )
+
             nuget install python -Version "$full_version" -ExcludeVersion
             python/tools/python -V
             python/tools/python -m venv env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
         type: string
 
     docker:
-      - image: cimg/python:<< parameters.python-version >>
+      - image: python:<< parameters.python-version >>
 
     steps:
       - checkout
@@ -221,7 +221,7 @@ jobs:
         type: string
 
     docker:
-      - image: cimg/python:<< parameters.python-version >>
+      - image: python:<< parameters.python-version >>
 
     steps:
       - checkout
@@ -318,7 +318,7 @@ workflows:
           context: &ctx-build "ocean-build"
           matrix:
             parameters:
-              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0rc3"]
               dimod-numpy-version: ["", "dimod~=0.9.0 numpy~=1.23.0", "dimod~=0.10.0", "dimod~=0.11.0", "dimod~=0.12.0"]
             exclude:
               # dimod < 0.10 not supported on py310+
@@ -328,6 +328,8 @@ workflows:
                 dimod-numpy-version: "dimod~=0.9.0 numpy~=1.23.0"
               - python-version: "3.12"
                 dimod-numpy-version: "dimod~=0.9.0 numpy~=1.23.0"
+              - python-version: "3.13.0rc3"
+                dimod-numpy-version: "dimod~=0.9.0 numpy~=1.23.0"
               # dimod < 0.12 not supported on py311+
               - python-version: "3.11"
                 dimod-numpy-version: "dimod~=0.10.0"
@@ -336,6 +338,10 @@ workflows:
               - python-version: "3.12"
                 dimod-numpy-version: "dimod~=0.10.0"
               - python-version: "3.12"
+                dimod-numpy-version: "dimod~=0.11.0"
+              - python-version: "3.13.0rc3"
+                dimod-numpy-version: "dimod~=0.10.0"
+              - python-version: "3.13.0rc3"
                 dimod-numpy-version: "dimod~=0.11.0"
 
       - test-macos:

--- a/releasenotes/notes/add-py313-support-20983f9f1ec5a684.yaml
+++ b/releasenotes/notes/add-py313-support-20983f9f1ec5a684.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add Python 3.13 support.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ dimod>=0.10.5,!=0.11.4
 numpy>=1.17.3
 
 # optional nlm support in dwave-optimization>0.1
-dwave-optimization>=0.1.0rc0
+dwave-optimization>=0.1.0
 
 # for solver mocks
 dwave-networkx>=0.8.10

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 setup(


### PR DESCRIPTION
Reworked the script on Windows to resolve and pull the latest Python version in order to support pre-releases.

Also, switched to using `python` docker images (full bookworm, ~400MB) for tests, instead of `cimg/python` ones (~800MB).

We still use the CircleCI images for jobs like build, deploy, docs, etc, but might consider moving them to standard Python images as well. The only package we would miss is `jq`, but that's required only for more advanced jobs (like some in the Ocean orb, or the windows python install).