### PR TITLE
Avoid `sampleset.wait_id` overwrite with dimod 0.12.18+

### DIFF
--- a/dwave/cloud/computation.py
+++ b/dwave/cloud/computation.py
@@ -801,9 +801,12 @@ class Future(object):
             energy=self.energies, num_occurrences=self.num_occurrences,
             info=info, sort_labels=True)
 
-        # the id is stored in the info field, but to be consistent with
-        # the samplesets constructed .from_future, we add the method as well
-        sampleset.wait_id = self.wait_id
+        if not hasattr(sampleset, 'wait_id'):
+            # the id is stored in the info field, but to be consistent with the
+            # samplesets constructed .from_future, we add the method as well
+            # note: sampleset has .wait_id() since dimod 0.12.18+, but we want
+            # to support older dimods as well
+            sampleset.wait_id = self.wait_id
 
         # cache the constructed sampleset on computation, but don't prevent the
         # gc from collecting it if unused in parent closure
@@ -832,10 +835,12 @@ class Future(object):
 
         sampleset = dimod.SampleSet.from_future(self, lambda f: f.wait_sampleset())
 
-        # propagate id to sampleset as well
-        # note: this requires dimod>=0.8.21 (before that version SampleSet
-        # had slots set which prevented dynamic addition of attributes).
-        sampleset.wait_id = self.wait_id
+        if not hasattr(sampleset, 'wait_id'):
+            # the id is stored in the info field, but to be consistent with the
+            # samplesets constructed .from_future, we add the method as well
+            # note: sampleset has .wait_id() since dimod 0.12.18+, but we want
+            # to support older dimods as well
+            sampleset.wait_id = self.wait_id
 
         return sampleset
 

--- a/releasenotes/notes/fix-sampleset.wait_id-double-add-with-latest-dimod-e7aee85c0cd3b252.yaml
+++ b/releasenotes/notes/fix-sampleset.wait_id-double-add-with-latest-dimod-e7aee85c0cd3b252.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Update sample set creation in ``dwave.cloud.computation.Future`` to support
+    dimod 0.12.18+. Previously, ``wait_id()`` method used to be added to the
+    ``from_future``-created sample sets in the cloud-client, and now the ``SampleSet``
+    interface propagates ``wait_id`` from the future by default.
+    See `dimod#1392 <https://github.com/dwavesystems/dimod/issues/1392>`_ and
+    `dwave-system#540 <https://github.com/dwavesystems/dwave-system/issues/540>`_.


### PR DESCRIPTION
This is to support the fix to [dwave-system#540](https://github.com/dwavesystems/dwave-system/issues/540) in [dimod#1393](https://github.com/dwavesystems/dimod/pull/1393).