### PR TITLE
Release 0.13.2

### DIFF
--- a/dwave/cloud/package_info.py
+++ b/dwave/cloud/package_info.py
@@ -14,7 +14,7 @@
 
 __packagename__ = 'dwave-cloud-client'
 __title__ = 'D-Wave Cloud Client'
-__version__ = '0.13.1'
+__version__ = '0.13.2'
 __author__ = 'D-Wave Systems Inc.'
 __description__ = 'A minimal client for interacting with D-Wave cloud resources.'
 __url__ = 'https://github.com/dwavesystems/dwave-cloud-client'


### PR DESCRIPTION
0.13.2
--------

### New Features

-   Add Python 3.13 support.

<!-- -->

-   Add `--raw` output mode to get-token CLI commands. See [\#598](https://github.com/dwavesystems/dwave-cloud-client/issues/598).

### Upgrade Notes

-   Remove support for dimod 0.9.x. Upgrade dimod to 0.10.0+. See [\#595](https://github.com/dwavesystems/dwave-cloud-client/issues/595).

<!-- -->

-   Upgrade your python to 3.9+. We no longer support python 3.8 and below.

### Deprecation Notes

-   Client utility function `dwave.cloud.coders.bqm_as_file()` is deprecated in favor of `dimod.BQM.to_file()` (available in dimod 0.10.0+) and will be removed in dwave-cloud-client 0.15.0.

### Bug Fixes

-   Update sample set creation in `dwave.cloud.computation.Future` to support dimod 0.12.18+. Previously, `wait_id()` method used to be added to the `from_future`-created sample sets in the cloud-client, and now the `SampleSet` interface propagates `wait_id` from the future by default. See [dimod\#1392](https://github.com/dwavesystems/dimod/issues/1392) and [dwave-system\#540](https://github.com/dwavesystems/dwave-system/issues/540).
