### PR TITLE
Thread-safe client close

### DIFF
--- a/dwave/cloud/client/base.py
+++ b/dwave/cloud/client/base.py
@@ -480,9 +480,6 @@ class Client(object):
         if not self.config.token:
             raise ValueError("API token not defined")
 
-        # Create session for main thread only
-        self.session = self.create_session()
-
         # Build the problem submission queue, start its workers
         self._submission_queue = queue.Queue()
         self._submission_workers = []
@@ -639,9 +636,6 @@ class Client(object):
             self._closed = True
 
         self._shutdown_threads(wait=True)
-
-        # Close the main thread's sessions
-        self.session.close()
 
         solvers_session = getattr(self, '_solvers_session', None)
         if solvers_session:

--- a/dwave/cloud/client/base.py
+++ b/dwave/cloud/client/base.py
@@ -698,6 +698,7 @@ class Client(object):
         return {r.code: {"name": r.name, "endpoint": r.endpoint} for r in rs}
 
     @property
+    @_ensure_active
     def solvers_session(self) -> api.resources.Solvers:
         session = getattr(self, '_solvers_session', None)
 

--- a/releasenotes/notes/robust-client-closing-e766edb5365ce83c.yaml
+++ b/releasenotes/notes/robust-client-closing-e766edb5365ce83c.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Disable client use while ``Client.close()`` is in progress by failing with
+    ``UseAfterCloseError``.
+
+    A follow-up to `#680 <https://github.com/dwavesystems/dwave-cloud-client/pull/680>`_.

--- a/releasenotes/notes/robust-client-closing-e766edb5365ce83c.yaml
+++ b/releasenotes/notes/robust-client-closing-e766edb5365ce83c.yaml
@@ -5,3 +5,7 @@ features:
     ``UseAfterCloseError``. Also, make sure the close operation is thread-safe.
 
     A follow-up to `#680 <https://github.com/dwavesystems/dwave-cloud-client/pull/680>`_.
+upgrade:
+  - |
+    Remove ``Client.session``, an undocumented and unused client attribute. If
+    still needed, can be replaced with ``Client.create_session()``.

--- a/releasenotes/notes/robust-client-closing-e766edb5365ce83c.yaml
+++ b/releasenotes/notes/robust-client-closing-e766edb5365ce83c.yaml
@@ -2,6 +2,6 @@
 features:
   - |
     Disable client use while ``Client.close()`` is in progress by failing with
-    ``UseAfterCloseError``.
+    ``UseAfterCloseError``. Also, make sure the close operation is thread-safe.
 
     A follow-up to `#680 <https://github.com/dwavesystems/dwave-cloud-client/pull/680>`_.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -620,7 +620,8 @@ class ClientConstruction(unittest.TestCase):
         # http retry params from config file propagated to client object
         with mock.patch("dwave.cloud.config.loaders.load_profile_from_files", lambda *pa, **kw: conf):
             with dwave.cloud.Client.from_config() as client:
-                retry = client.session.get_adapter('https://').max_retries
+                session = client.create_session()
+                retry = session.get_adapter('https://').max_retries
                 self._verify_retry_config(retry, retry_opts)
 
         # test defaults
@@ -645,7 +646,8 @@ class ClientConstruction(unittest.TestCase):
 
         with mock.patch("dwave.cloud.config.loaders.load_profile_from_files", lambda *pa, **kw: conf):
             with dwave.cloud.Client.from_config(**retry_kwargs) as client:
-                retry = client.session.get_adapter('https://').max_retries
+                session = client.create_session()
+                retry = session.get_adapter('https://').max_retries
                 self._verify_retry_config(retry, retry_kwargs)
 
 
@@ -704,7 +706,7 @@ class ClientConfigIntegration(unittest.TestCase):
         with mock.patch("dwave.cloud.config.loaders.open", iterable_mock_open(config_body)):
             with Client.from_config('config_file', profile='custom') as client:
                 # check permissive_ssl and timeouts custom params passed-thru
-                self.assertFalse(client.session.verify)
+                self.assertTrue(client.config.permissive_ssl)
                 self.assertEqual(client.config.request_timeout, request_timeout)
                 self.assertEqual(client.config.polling_timeout, polling_timeout)
 

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -1166,6 +1166,18 @@ class TestClientClose(MockSubmissionBase, unittest.TestCase):
 
         self.assertIsNone(ref())
 
+    def test_solvers_session_access_fails(self):
+        with Client(**self.config) as client:
+            self.assertIsNotNone(client.solvers_session)
+
+        # session is closed and disabled
+        with self.assertRaises(UseAfterCloseError):
+            client.solvers_session
+
+        # hence, get_solver fails as well
+        with self.assertRaises(UseAfterCloseError):
+            client.get_solver()
+
 
 @mock.patch('time.sleep', lambda *x: None)
 class TestClientUseWhileClosing(MockSubmissionBase, unittest.TestCase):


### PR DESCRIPTION
A follow-up to #680, in which we make sure client use is disabled also during _closing_, not just after the client has been closed.

We also make sure `close()` is thread-safe wrt attempted usage while closing.

~TODO: consider converting `Client.solvers_session` to a ctxmgr, or making this session ephemeral in another way.~
:arrow_right:  Keeping `Client.solvers_session` active during client lifespan, as it saves ~3ms on init due to disk cache access.