### PR TITLE
Fix a bug in get_regions test

### DIFF
--- a/dwave/cloud/client/base.py
+++ b/dwave/cloud/client/base.py
@@ -40,7 +40,6 @@ import time
 import copy
 import queue
 import logging
-import warnings
 import operator
 import threading
 

--- a/dwave/cloud/regions.py
+++ b/dwave/cloud/regions.py
@@ -80,11 +80,23 @@ def get_regions(config: Optional[Union[ClientConfig, str, dict]] = None,
         ``maxage`` parameter is now just a default value for the maximum allowed
         cache age, and it's typically overridden by regions API's cache control.
 
-    Example:
+    Examples:
+        Fetch available regions using the default client configuration:
+
         >>> from dwave.cloud.regions import get_regions
         >>> get_regions()       # doctest: +NORMALIZE_WHITESPACE
         [Region(code='na-west-1', name='North America', endpoint='https://na-west-1.cloud.dwavesys.com/sapi/v2/'),
          Region(code='eu-central-1', name='Europe', endpoint='https://eu-central-1.cloud.dwavesys.com/sapi/v2/')]
+
+        Alternatively, to fetch available regions using an already configured client:
+
+        .. code::
+
+            from dwave.cloud import Client
+            from dwave.cloud.regions import get_regions
+
+            with Client.from_config(...) as client:
+                get_regions(config=client.config)
 
     """
     if isinstance(config, str):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,7 +18,6 @@ Tests the ability to connect to the SAPI server with the `dwave.cloud.qpu.Client
 test_mock_solver_loading.py duplicates some of these tests against a mock server.
 """
 
-import importlib
 import json
 import sys
 import threading
@@ -33,7 +32,7 @@ import requests
 from parameterized import parameterized
 from plucky import merge
 
-from dwave.cloud.api import models
+from dwave.cloud.api import models, Regions
 from dwave.cloud.client import Client
 from dwave.cloud.config import constants
 from dwave.cloud.config.models import dump_config_v1, PollingStrategy
@@ -770,7 +769,7 @@ class MultiRegionSupport(unittest.TestCase):
             self.assertEqual(config.permissive_ssl, permissive_ssl)
             self.assertEqual(config.proxy, proxy)
 
-            regions = models.Regions()
+            regions = Regions()
             regions._session = _mocked_session()
             return regions
 
@@ -782,7 +781,7 @@ class MultiRegionSupport(unittest.TestCase):
                     # (i.e. config open mock above fails on CI)
                     with Client.from_config(config_file='config_file') as client:
                         # verify get_regions() returns data from metadata_api_endpoint
-                        regions = get_regions()
+                        regions = get_regions(config=client.config)
                         self.assertEqual(regions, expected_get_regions_return)
 
                         # check region endpoint initialized from custom metadata_api_endpoint


### PR DESCRIPTION
A bug in tests was introduced while removing `Client.get_regions()`.

The bug was not evident in https://github.com/dwavesystems/dwave-cloud-client/pull/710 until we merged it with a fix of multi-region tests in 09ef1f4427 done as part of https://github.com/dwavesystems/dwave-cloud-client/pull/702.

Note to self: always rebase a PR before merging.