### PR TITLE
Release 0.14.0

### DIFF
--- a/dwave/cloud/package_info.py
+++ b/dwave/cloud/package_info.py
@@ -14,7 +14,7 @@
 
 __packagename__ = 'dwave-cloud-client'
 __title__ = 'D-Wave Cloud Client'
-__version__ = '0.14.0rc1'
+__version__ = '0.14.0'
 __author__ = 'D-Wave Systems Inc.'
 __description__ = 'A minimal client for interacting with D-Wave cloud resources.'
 __url__ = 'https://github.com/dwavesystems/dwave-cloud-client'


### PR DESCRIPTION
### Prelude

Solver identification has changed with SAPI solver representation v3. Instead of a unique string `id`, each solver is now uniquely referenced by a more descriptive `identity` dictionary. Each solver still has a `name`, but to uniquely identify a specific working graph of a structured solver (QPU), `graph_id` has to be used. Hybrid (unstructured) solvers are still uniquely identified by their `name`.

### New Features

-   Allow `solver` to be specified using the new solver identity string representation.

    The new format is supported in a config file:

        [my-experiment]
        solver = Advantage_system6.4;graph_id=01dae5a273

    environment variable:

        DWAVE_API_SOLVER='Advantage_system6.4;graph_id=01dae5a273'

    as an argument to the `dwave` CLI:

        dwave solvers -s 'Advantage_system6.4;graph_id=01dae5a273'

    or as the client constructor argument:

        from dwave.cloud import Client

        with Client.from_config(solver='Advantage_system6.4;graph_id=01dae5a273') as client:
          solver = client.get_solver()

          assert(solver.name == 'Advantage_system6.4')
          assert(solver.graph_id == '01dae5a273')

    Note: specifying your solver via name only is still possible. In that case, working graph version is not constrained.

    See [\#714](https://github.com/dwavesystems/dwave-cloud-client/issues/714).

<!-- -->

-   Pass-through unused keyword arguments in `dwave.cloud.utils.http.BaseUrlSessionMixin` constructor. This enables mixing with session mixins from `dwave.cloud.api.client` in any order.

<!-- -->

-   Enable `DWaveAPIClient` to properly cache different API response representation versions by reordering session mixins. Caching layer is now below the API version handling, hence capturing changes from the versioning layer.

<!-- -->

-   Facilitate cached content validation and parsing by caching the response content type as part of metadata in `dwave.cloud.api.client.CachingSessionMixin`.

<!-- -->

-   Make `SolverIdentity` string representation more explicit. Version components are now clearly identified, avoiding ambiguity and enabling reverse lookups (i.e. conversion between string representation and solver identity structure).

    Add `SolverIdentity.from_id()` factory that creates solver identity model off its string representation.

    See [\#713](https://github.com/dwavesystems/dwave-cloud-client/issues/713).

<!-- -->

-   Implement support for SAPI v3 solver representation format. Use it by default.

    Use `Solver.identity` instead of `Solver.id` to uniquely reference a specific solver and its version.

    See [\#696](https://github.com/dwavesystems/dwave-cloud-client/issues/696).

<!-- -->

-   Feature-based solver filtering via `Client.get_solver()` and `Client.get_solvers()` has been extended to support the new `identity` field (dict), `version` (dict) and `graph_id` (string). For example:

        client.get_solvers(name='Advantage_system6.4', graph_id='01dae5a273')
        client.get_solvers(graph_id='01dae5a273')
        client.get_solvers(version__graph_id='01dae5a273')
        client.get_solvers(identity__version={'graph_id': '01dae5a273'})
        client.get_solvers(category='qpu', order_by='graph_id')
        client.get_solver(id='Advantage_system6.4:01dae5a273')

<!-- -->

-   Add `SolverVersion` and `SolverIdentity` to `dwave.cloud.api.models`. They both compare with a `dict`, and serialize with `.dict()` for convenience.

<!-- -->

-   Speed-up `StructuredSolver` construction by deferring initialization of large data members. `nodes`, `edges` and `undirected_edges` are now cached properties, constructed on first access. See [\#706](https://github.com/dwavesystems/dwave-cloud-client/issues/706).

<!-- -->

-   Add `dwave cache` group of commands for listing cache directories used by the cloud-client, displaying additional information about the cache, as well as purging it. See [\#719](https://github.com/dwavesystems/dwave-cloud-client/issues/719).

<!-- -->

-   Add support for Leap deprecation messages to `dwave.cloud.client.Client` and `dwave.cloud.api.client.DWaveAPIClient`.

    Deprecation messages received are raised as Python warnings using a new category, `dwave.cloud.api.exceptions.ResourceDeprecationWarning` and logged using the `WARNING` log level.

    See [\#721](https://github.com/dwavesystems/dwave-cloud-client/issues/721).

<!-- -->

-   Enable the previous client close behavior to wait for all remote jobs to finish.

    Waiting for all jobs to finish and their results to be downloaded before shutting down the client is now the new default. To close the client as fast as possible (immediately preventing status polls and answer downloads), set the `wait` argument to false: `Client.close(wait=False)`.

    See [\#712](https://github.com/dwavesystems/dwave-cloud-client/issues/712).

### Upgrade Notes

-   Switch to using solver's `identity` structure in place of the legacy string `id`.

<!-- -->

-   `Solver.data` type changed from a raw dict (as returned by SAPI) to the `dwave.cloud.api.models.SolverConfiguration` model. This is mostly a backwards-compatible change, since getter/setter interface is supported.

<!-- -->

-   The type of `solver` argument to `dwave.cloud.api.resources.Problems` methods (`submit_problem` and `list_problems`) changed from a string, to a `SolverIdentity` model.

<!-- -->

-   `dwave.cloud.Client.get_regions()` which has been deprecated since cloud-client 0.11.0, is now removed in favor of `dwave.cloud.regions.get_regions()`. Usage example available in the [docs](https://docs.dwavequantum.com/en/latest/ocean/api_ref_cloud/generated/dwave.cloud.regions.get_regions.html).

    The main benefit of `get_regions` as a stand-alone function is that `Client` doesn't have to be instantiated (and configured to use the default region), just to be able to fetch the list of regions.

<!-- -->

-   We removed (previously deprecated) aliases for client types.

    Replace your `Client` imports from `dwave.cloud.{type}` with imports from `dwave.cloud.client.{type}` (`type` being `qpu`, `sw` or `hybrid`).

<!-- -->

-   Remove API constants deprecated in 0.13.1 and moved to `dwave.cloud.config.constants` from `dwave.cloud.api.constants`: `DEFAULT_METADATA_API_ENDPOINT`, `DEFAULT_REGION`, `DEFAULT_SOLVER_API_ENDPOINT`, `DEFAULT_LEAP_API_ENDPOINT`.

<!-- -->

-   `dwave.cloud.utils.coders.NumpyEncoder` is now removed in favor of `orjson.dumps()` used with the `OPT_SERIALIZE_NUMPY` flag. We first deprecated `NumpyEncoder` in dwave-cloud-client 0.12.2.

### Deprecation Notes

-   `Solver.id` is deprecated in favor of `Solver.identity`. Solver "ID" is not available anymore, so it's constructed on the fly from the `identity` field, with the uniqueness assumption preserved.

<!-- -->

-   `solver_id` argument in `dwave.cloud.api.resources.Solvers.get_solver()` is deprecated in favor of `solver_name`.

### Bug Fixes

-   Fix tests to never (accidentally) contact 3rd-party mock sites nor depend on their functionality. See [\#707](https://github.com/dwavesystems/dwave-cloud-client/issues/707).

<!-- -->

-   Make answer field optional on the `dwave.cloud.api.models.ProblemInfo` model in order to support problems not completed (e.g. pending or failed). See [\#703](https://github.com/dwavesystems/dwave-cloud-client/issues/703).

<!-- -->

-   Preserve `Content-Type` of a response cached with `CachingSessionMixin`.
