### PR TITLE
Fix errors on glossary terms in ocean SDK

### DIFF
--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -794,9 +794,9 @@ class CQMSolver(BaseUnstructuredSolver):
 
 
 class NLSolver(BaseUnstructuredSolver):
-    """NL solver interface.
+    """Nonlinear solver interface.
 
-    This class provides an :term:`NL model` sampling method and encapsulates
+    This class provides a :term:`nonlinear model` sampling method and encapsulates
     the solver description returned from the D-Wave cloud API.
 
     Args:
@@ -849,7 +849,7 @@ class NLSolver(BaseUnstructuredSolver):
                    upload_params: Optional[dict] = None,
                    **sample_params
                    ) -> Future:
-        """Sample from the specified :term:`NL model`.
+        """Sample from the specified :term:`nonlinear model`.
 
         Args:
             model (:class:`~dwave.optimization.Model`/bytes/str):
@@ -901,8 +901,8 @@ class NLSolver(BaseUnstructuredSolver):
                    model: Union['dwave.optimization.Model', io.IOBase, bytes],
                    **upload_params,
                    ) -> concurrent.futures.Future:
-        r"""Upload the specified :term:`NL model` to SAPI, returning a Problem ID
-        that can be used to submit the NL model to this solver (i.e. call the
+        r"""Upload the specified :term:`nonlinear model` to SAPI, returning a Problem ID
+        that can be used to submit the nonlinear model to this solver (i.e. call the
         :meth:`.sample_nlm` method).
 
         Args:


### PR DESCRIPTION
Current use of :term:`NL model` causes [build errors](https://app.circleci.com/pipelines/github/dwavesystems/dwave-ocean-sdk/3084/workflows/295ea15f-0f2a-417b-baf1-645301712528/jobs/43520/parallel-runs/0/steps/0-106) in SDK: 

```
/root/project/env/lib/python3.11/site-packages/dwave/cloud/solver.py:docstring of dwave.cloud.solver.NLSolver.sample_nlm:1: WARNING: term not in glossary: 'NL model'
/root/project/env/lib/python3.11/site-packages/dwave/cloud/solver.py:docstring of dwave.cloud.solver.NLSolver.upload_nlm:1: WARNING: term not in glossary: 'NL model'
/root/project/docs/ocean/api_ref_cloud/solver.rst:53:<autosummary>:1: WARNING: term not in glossary: 'NL model'
/root/project/docs/ocean/api_ref_cloud/solver.rst:53:<autosummary>:1: WARNING: term not in glossary: 'NL model'
```

We can also add the term "NL model" to the [existing glossary term](https://docs.dwavequantum.com/en/latest/concepts/index.html#term-nonlinear-model) but the term used in the docs is "nonlinear model". 