### PR TITLE
Release 0.14.1

### DIFF
--- a/dwave/cloud/package_info.py
+++ b/dwave/cloud/package_info.py
@@ -14,7 +14,7 @@
 
 __packagename__ = 'dwave-cloud-client'
 __title__ = 'D-Wave Cloud Client'
-__version__ = '0.14.0'
+__version__ = '0.14.1'
 __author__ = 'D-Wave Systems Inc.'
 __description__ = 'A minimal client for interacting with D-Wave cloud resources.'
 __url__ = 'https://github.com/dwavesystems/dwave-cloud-client'


### PR DESCRIPTION
### New Features

-   Add Python 3.14 support. See [\#730](https://github.com/dwavesystems/dwave-cloud-client/pull/730).

<!-- -->

-   Implement `close()` method and context protocol support on `AuthFlow` and `LeapAuthFlow` classes.

### Upgrade Notes

-   Upgrade your Python to 3.10+. We no longer support Python 3.9 and below. See [\#726](https://github.com/dwavesystems/dwave-cloud-client/pull/726).

### Deprecation Notes

-   `Solver.is_vfyc` property is deprecated since dwave-cloud-client 0.14.1 and will be removed in 0.15.0. Note that Leap QPU solvers in general don't support the `vfyc` (virtual full-yield chip) property anymore. See [\#725](https://github.com/dwavesystems/dwave-cloud-client/pull/725).

### Bug Fixes

-   Workaround for SAPI returning invalid v3 solver representation of problems submitted using v2 representation (with Ocean &lt; 9). When `Client.retrieve_answer()` receives a solver identity with `graph_id` missing, we fall back to a partial solver match (based on name only). See [\#727](https://github.com/dwavesystems/dwave-cloud-client/issues/727).

<!-- -->

-   Fix resource leaks during diskcache/sqlite database use in `CachingSessionMixin`, `LeapAuthFlow` and `@cached`. See [\#731](https://github.com/dwavesystems/dwave-cloud-client/issues/731).
