### PR TITLE
Upgrade http-sf to fix date parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ werkzeug>=3.1.0,<4
 typing-extensions>=4.5.0,<5
 authlib>=1.2,<2
 orjson>=3.11
-http-sf>=1.0.4
+http-sf>=1.2.1
 
 # bring in py312 semantics of importlib.metadata.entry_points()
 importlib_metadata>=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = ['requests[socks]>=2.25,<3', 'urllib3>=1.26,<3',
                     'diskcache>=5.2.1,<6', 'packaging>=19', 'werkzeug>=3.1.0,<4',
                     'typing-extensions>=4.5.0,<5', 'authlib>=1.2,<2',
                     'importlib_metadata>=5.0.0',    # can be dropped in py312+
-                    'orjson>=3.11', 'http-sf>=1.0.4',
+                    'orjson>=3.11', 'http-sf>=1.2.1',
                     ]
 
 # Package extras requirements

--- a/tests/api/test_api_clients.py
+++ b/tests/api/test_api_clients.py
@@ -872,7 +872,7 @@ class TestDeprecationMessageParsing(unittest.TestCase):
         self.mocker = requests_mock.Mocker()
 
         # structured field date is in integer seconds
-        now = datetime.datetime.now().replace(microsecond=0)
+        now = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
 
         self.dep_id = 'dep-1'
         self.dep_params = dict(


### PR DESCRIPTION
Older versions of http-sf didn't correctly parse input dates. Namely, naive datetime was produced instead of timezone-aware. Note the input date is coded as unix epoch timestamp, so it's always in UTC -- that was not reflected in the parsed result.

See also: https://github.com/mnot/http-sf/pull/21.