### PR TITLE
Define minimal problem per solver class and simplify solver pinging

### DIFF
--- a/docs/solver.rst
+++ b/docs/solver.rst
@@ -15,6 +15,7 @@ Class
 .. autoclass:: Solver
 .. autoclass:: BaseSolver
 .. autoclass:: StructuredSolver
+.. autoclass:: BaseUnstructuredSolver
 .. autoclass:: UnstructuredSolver
 
 
@@ -28,28 +29,38 @@ Methods
    StructuredSolver.estimate_qpu_access_time
    StructuredSolver.max_num_reads
    StructuredSolver.reformat_parameters
-   StructuredSolver.sample_bqm
    StructuredSolver.sample_ising
    StructuredSolver.sample_qubo
+   StructuredSolver.sample_bqm
+   StructuredSolver.sample_problem
 
    UnstructuredSolver.sample_ising
    UnstructuredSolver.sample_qubo
    UnstructuredSolver.sample_bqm
+   UnstructuredSolver.sample_problem
    UnstructuredSolver.upload_bqm
 
    BQMSolver.sample_ising
    BQMSolver.sample_qubo
    BQMSolver.sample_bqm
+   BQMSolver.sample_problem
    BQMSolver.upload_bqm
 
    CQMSolver.sample_cqm
+   CQMSolver.sample_problem
    CQMSolver.upload_cqm
 
    DQMSolver.sample_dqm
+   DQMSolver.sample_problem
    DQMSolver.upload_dqm
 
    NLSolver.sample_nlm
+   NLSolver.sample_problem
    NLSolver.upload_nlm
+
+   QCDLSolver.sample_qcdl
+   QCDLSolver.sample_problem
+   QCDLSolver.upload_qcdl
 
 Properties
 ----------
@@ -64,6 +75,7 @@ Properties
    BaseSolver.qpu
    BaseSolver.hybrid
    BaseSolver.software
+   BaseSolver.minimal_problem
 
    StructuredSolver.nodes
    StructuredSolver.variables

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -32,7 +32,7 @@ import requests.exceptions
 
 from dwave.cloud import api
 from dwave.cloud.client import Client
-from dwave.cloud.solver import StructuredSolver, BaseUnstructuredSolver
+from dwave.cloud.solver import StructuredSolver, BQMSolver
 from dwave.cloud.utils.cli import default_text_input, strtrunc, CLIError
 from dwave.cloud.utils.dist import (
     get_contrib_packages, get_distribution, PackageNotFoundError, VersionNotFoundError)
@@ -660,20 +660,25 @@ def sample(*, config_file, profile, endpoint, region, client_type, solver_def,
     t0 = timer()
     client, solver = _get_client_solver(config, output)
 
+    _, minimal_params = solver.minimal_problem
+    params = minimal_params | params
+
+    if isinstance(solver, BQMSolver):
+        try:
+            import dimod
+        except ImportError: # pragma: no cover
+            raise RuntimeError("Can't sample from unstructured solver without dimod. "
+                               "Re-install the library with 'bqm' support.")
+
     if random_problem:
         if isinstance(solver, StructuredSolver):
             linear, quadratic = generate_random_ising_problem(solver)
-
-        elif isinstance(solver, BaseUnstructuredSolver):
-            try:
-                from dimod.generators import uniform
-            except ImportError: # pragma: no cover
-                raise RuntimeError("Can't sample from unstructured solver without dimod. "
-                                   "Re-install the library with 'bqm' support.")
-            linear, quadratic, _ = uniform(problem_size, 'SPIN').to_ising()
-
+            problem = (linear, quadratic, 0.0)
+        elif isinstance(solver, BQMSolver):
+            problem = bqm = dimod.generators.uniform(problem_size, 'SPIN')
+            linear, quadratic, _ = bqm.to_ising()
         else:
-            raise CLIError(f"Unhandled solver type: {solver!r}", code=99)
+            raise CLIError(f"Ising sampling not supported for solver: {solver!r}", code=99)
 
     else:
         try:
@@ -687,13 +692,20 @@ def sample(*, config_file, profile, endpoint, region, client_type, solver_def,
         except Exception as e:
             raise CLIError(f"Invalid couplings: {e}", code=99)
 
+        if isinstance(solver, StructuredSolver):
+            problem = (linear, quadratic, 0.0)
+        elif isinstance(solver, BQMSolver):
+            problem = dimod.BQM.from_ising(linear, quadratic)
+        else:
+            raise CLIError(f"Ising sampling not supported for solver: {solver!r}", code=99)
+
     output("Using biases: {linear}", linear=list(linear.items()), maxlen=maxlen)
     output("Using couplings: {quadratic}", quadratic=list(quadratic.items()), maxlen=maxlen)
     output("Sampling parameters: {sampling_params}", sampling_params=params)
 
     t1 = timer()
     response = _sample(
-        solver, problem=(linear, quadratic, 0.0), params=params, output=output)
+        solver, problem=problem, params=params, output=output)
 
     t2 = timer()
 

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -407,7 +407,7 @@ def _sample(solver, problem, params, output):
     """Blocking sample call with error handling and using custom printer."""
 
     try:
-        response = solver.sample_ising(*problem, **params)
+        response = solver.sample_problem(problem, **params)
         problem_id = response.wait_id()
         output("Submitted problem ID: {problem_id}", problem_id=problem_id)
         response.result()
@@ -531,12 +531,8 @@ def ping(*, config_file, profile, endpoint, region, client_type, solver_def,
     client, solver = _get_client_solver(config, output)
 
     # generate problem
-    if hasattr(solver, 'nodes'):
-        # structured solver: use the first existing node
-        problem = ({min(solver.nodes): 0}, {})
-    else:
-        # unstructured solver doesn't constrain problem graph
-        problem = ({0: 1}, {})
+    problem, min_params = solver.minimal_problem
+    params = min_params | params
 
     t1 = timer()
     response = _sample(solver, problem, params, output)
@@ -697,7 +693,7 @@ def sample(*, config_file, profile, endpoint, region, client_type, solver_def,
 
     t1 = timer()
     response = _sample(
-        solver, problem=(linear, quadratic), params=params, output=output)
+        solver, problem=(linear, quadratic, 0.0), params=params, output=output)
 
     t2 = timer()
 

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -19,6 +19,7 @@ import orjson
 import shutil
 import subprocess
 from collections import abc
+from collections.abc import Callable
 from configparser import ConfigParser
 from datetime import datetime
 from functools import wraps, partial
@@ -32,7 +33,9 @@ import requests.exceptions
 
 from dwave.cloud import api
 from dwave.cloud.client import Client
-from dwave.cloud.solver import StructuredSolver, BQMSolver
+from dwave.cloud.computation import Future
+from dwave.cloud.solver import (
+    StructuredSolver, QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver)
 from dwave.cloud.utils.cli import default_text_input, strtrunc, CLIError
 from dwave.cloud.utils.dist import (
     get_contrib_packages, get_distribution, PackageNotFoundError, VersionNotFoundError)
@@ -403,11 +406,13 @@ def _get_client_solver(config, output=None):
     return (client, solver)
 
 
-def _sample(solver, problem, params, output):
+def _sample(sample: Callable[[], Future],
+            output: Callable[..., None],
+            ) -> Future:
     """Blocking sample call with error handling and using custom printer."""
 
     try:
-        response = solver.sample_problem(problem, **params)
+        response = sample()
         problem_id = response.wait_id()
         output("Submitted problem ID: {problem_id}", problem_id=problem_id)
         response.result()
@@ -535,7 +540,8 @@ def ping(*, config_file, profile, endpoint, region, client_type, solver_def,
     params = min_params | params
 
     t1 = timer()
-    response = _sample(solver, problem, params, output)
+    sample = partial(solver.sample_problem, problem=problem, **params)
+    response = _sample(sample, output)
 
     t2 = timer()
     output("\nWall clock time:")
@@ -663,7 +669,10 @@ def sample(*, config_file, profile, endpoint, region, client_type, solver_def,
     _, minimal_params = solver.minimal_problem
     params = minimal_params | params
 
-    if isinstance(solver, BQMSolver):
+    if not isinstance(solver, (StructuredSolver, QuadraticUnstructuredSolverMixin)):
+        raise CLIError(f"Ising sampling not supported for solver: {solver!r}", code=99)
+
+    if isinstance(solver, BaseUnstructuredSolver):
         try:
             import dimod
         except ImportError: # pragma: no cover
@@ -673,12 +682,9 @@ def sample(*, config_file, profile, endpoint, region, client_type, solver_def,
     if random_problem:
         if isinstance(solver, StructuredSolver):
             linear, quadratic = generate_random_ising_problem(solver)
-            problem = (linear, quadratic, 0.0)
-        elif isinstance(solver, BQMSolver):
-            problem = bqm = dimod.generators.uniform(problem_size, 'SPIN')
-            linear, quadratic, _ = bqm.to_ising()
         else:
-            raise CLIError(f"Ising sampling not supported for solver: {solver!r}", code=99)
+            bqm = dimod.generators.uniform(problem_size, 'SPIN')
+            linear, quadratic, _ = bqm.to_ising()
 
     else:
         try:
@@ -692,20 +698,14 @@ def sample(*, config_file, profile, endpoint, region, client_type, solver_def,
         except Exception as e:
             raise CLIError(f"Invalid couplings: {e}", code=99)
 
-        if isinstance(solver, StructuredSolver):
-            problem = (linear, quadratic, 0.0)
-        elif isinstance(solver, BQMSolver):
-            problem = dimod.BQM.from_ising(linear, quadratic)
-        else:
-            raise CLIError(f"Ising sampling not supported for solver: {solver!r}", code=99)
-
+    problem = (linear, quadratic, 0.0)
     output("Using biases: {linear}", linear=list(linear.items()), maxlen=maxlen)
     output("Using couplings: {quadratic}", quadratic=list(quadratic.items()), maxlen=maxlen)
     output("Sampling parameters: {sampling_params}", sampling_params=params)
 
     t1 = timer()
-    response = _sample(
-        solver, problem=problem, params=params, output=output)
+    sample = partial(solver.sample_ising, *problem, **params)
+    response = _sample(sample, output)
 
     t2 = timer()
 

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -217,6 +217,23 @@ class BaseSolver:
         else:
             raise ValueError("Don't know how to decode %r answer format" % fmt)
 
+    # Sampling methods
+
+    def sample_problem(self,
+                       problem: Any,
+                       *,
+                       label: str | None = None,
+                       problem_type: str | None = None,
+                       upload_params: dict | None = None,
+                       **sample_params: Any,
+                       ) -> Future:
+        """Sample from the specified problem."""
+        raise NotImplementedError
+
+    def upload_problem(self, problem: Any, **kwargs: Any):
+        """Encode and upload the specified problem."""
+        raise NotImplementedError
+
     # Derived properties
 
     @property
@@ -318,7 +335,7 @@ class QuadraticUnstructuredSolverMixin:
             import dimod
         except ImportError: # pragma: no cover
             raise RuntimeError("Can't use unstructured quadratic solver without dimod. "
-                               "Re-install the library with bqm support.")
+                               "Re-install the library with 'bqm' support.")
 
         bqm = dimod.BinaryQuadraticModel.from_ising(linear, quadratic, offset)
         return self.sample_bqm(bqm, label=label, **params)
@@ -353,7 +370,7 @@ class QuadraticUnstructuredSolverMixin:
             import dimod
         except ImportError: # pragma: no cover
             raise RuntimeError("Can't use unstructured quadratic solver without dimod. "
-                               "Re-install the library with bqm support.")
+                               "Re-install the library with 'bqm' support.")
 
         bqm = dimod.BinaryQuadraticModel.from_qubo(qubo, offset)
         return self.sample_bqm(bqm, label=label, **params)
@@ -1222,6 +1239,50 @@ class StructuredSolver(BaseSolver):
 
         return self._sample(problem_type, linear, quadratic, bqm.offset,
                             params, label=label, undirected_biases=True)
+
+    def sample_problem(self,
+                       problem: tuple[list | dict[int, float],
+                                      dict[tuple[int, int], float],
+                                      float],
+                       *,
+                       problem_type: Literal['ising', 'qubo'] = 'ising',
+                       undirected_biases: bool = False,
+                       label: str | None = None,
+                       upload_params: dict | None = None,
+                       **sample_params: Any,
+                       ) -> Future:
+        """Sample from the specified problem.
+
+        Args:
+            problem:
+                Tuple with linear/quadratic terms of the model and the offset.
+
+            problem_type:
+                Problem type, one of the handled problem types by the solver.
+
+            undirected_biases:
+                Are (quadratic) biases specified on undirected edges? For
+                triangular or symmetric matrix of quadratic biases set it to
+                ``True``.
+
+            label:
+                Problem label you can optionally tag submissions with for ease
+                of identification.
+
+            upload_params:
+                Optional upload/encode parameters, not used by structured solvers.
+
+            **sample_params:
+                Sampling parameters, solver-specific.
+
+        Returns:
+            Response in a future.
+
+        """
+        linear, quadratic, offset = problem
+        return self._sample(type_=problem_type, linear=linear, quadratic=quadratic,
+                            offset=offset, undirected_biases=undirected_biases,
+                            label=label, params=sample_params)
 
     @dispatches_events('sample')
     def _sample(self, type_, linear, quadratic, offset, params,

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -89,10 +89,6 @@ if TYPE_CHECKING:
 class BaseSolver:
     """Base class for a general D-Wave solver.
 
-    This class provides :term:`Ising`, :term:`QUBO` and :term:`BQM` sampling
-    methods and encapsulates the solver description returned from the D-Wave
-    cloud API.
-
     Args:
         client (:class:`Client`):
             Client that manages access to this solver.
@@ -221,19 +217,6 @@ class BaseSolver:
         else:
             raise ValueError("Don't know how to decode %r answer format" % fmt)
 
-    # Sampling methods
-    def sample_ising(self, linear, quadratic, **params):
-        raise NotImplementedError
-
-    def sample_qubo(self, qubo, **params):
-        raise NotImplementedError
-
-    def sample_bqm(self, bqm, **params):
-        raise NotImplementedError
-
-    def upload_bqm(self, bqm):
-        raise NotImplementedError
-
     # Derived properties
 
     @property
@@ -295,22 +278,9 @@ class BaseSolver:
             return self.name.startswith('hybrid')
 
 
-class BaseUnstructuredSolver(BaseSolver):
-    """Base class for D-Wave unstructured solvers.
-
-    This class provides :term:`Ising`, :term:`QUBO` and :term:`BQM` sampling
-    methods and encapsulates the solver description returned from the D-Wave
-    cloud API.
-
-    Args:
-        client (:class:`~dwave.cloud.client.Client`):
-            Client that manages access to this solver.
-
-        data (`dict`):
-            Data from the server describing this solver.
-
-    Note:
-        Events are not yet dispatched from unstructured solvers.
+class QuadraticUnstructuredSolverMixin:
+    """Implements quadratic problem solver interface by providing Ising/QUBO
+    sampling methods for solvers that support sampling from a :class:`~dimod.BQM`.
     """
 
     def sample_ising(self, linear, quadratic, offset=0, label=None, **params):
@@ -347,8 +317,8 @@ class BaseUnstructuredSolver(BaseSolver):
         try:
             import dimod
         except ImportError: # pragma: no cover
-            raise RuntimeError("Can't use unstructured solver without dimod. "
-                               "Re-install the library with bqm/cqm/dqm support.")
+            raise RuntimeError("Can't use unstructured quadratic solver without dimod. "
+                               "Re-install the library with bqm support.")
 
         bqm = dimod.BinaryQuadraticModel.from_ising(linear, quadratic, offset)
         return self.sample_bqm(bqm, label=label, **params)
@@ -382,11 +352,32 @@ class BaseUnstructuredSolver(BaseSolver):
         try:
             import dimod
         except ImportError: # pragma: no cover
-            raise RuntimeError("Can't use unstructured solver without dimod. "
-                               "Re-install the library with bqm/cqm/dqm support.")
+            raise RuntimeError("Can't use unstructured quadratic solver without dimod. "
+                               "Re-install the library with bqm support.")
 
         bqm = dimod.BinaryQuadraticModel.from_qubo(qubo, offset)
         return self.sample_bqm(bqm, label=label, **params)
+
+
+class BaseUnstructuredSolver(BaseSolver):
+    """Base class for D-Wave unstructured solvers.
+
+    Implements :meth:`.upload_problem` and :meth:`.sample_problem`.
+
+    To implement support for a specific solver (type), a subclass has to
+    provide problem encoders for upload and sample operations by implementing both
+    :meth:`._encode_problem_for_upload` and :meth:`._encode_problem_for_submission`.
+
+    Args:
+        client (:class:`~dwave.cloud.client.Client`):
+            Client that manages access to this solver.
+
+        data (`dict`):
+            Data from the server describing this solver.
+
+    Note:
+        Events are not yet dispatched from unstructured solvers.
+    """
 
     def _encode_problem_for_upload(self, problem, **kwargs):
         """Encode problem for upload to solver.
@@ -543,7 +534,7 @@ class BaseUnstructuredSolver(BaseSolver):
         return computation
 
 
-class BQMSolver(BaseUnstructuredSolver):
+class BQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
     """Class for D-Wave unstructured binary quadratic model solvers.
 
     This class provides :term:`Ising`, :term:`QUBO` and :term:`BQM` sampling
@@ -610,7 +601,7 @@ class BQMSolver(BaseUnstructuredSolver):
         return self.upload_problem(bqm)
 
 
-class DQMSolver(BaseUnstructuredSolver):
+class DQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
     """Class for D-Wave unstructured discrete quadratic model solvers.
 
     This class provides a :term:`DQM` sampling
@@ -714,7 +705,7 @@ class DQMSolver(BaseUnstructuredSolver):
         return self.upload_problem(dqm)
 
 
-class CQMSolver(BaseUnstructuredSolver):
+class CQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
     """Class for D-Wave unstructured constrained quadratic model solvers.
 
     This class provides a :term:`CQM` sampling method and encapsulates the
@@ -793,7 +784,7 @@ class CQMSolver(BaseUnstructuredSolver):
         return self.upload_problem(cqm)
 
 
-class NLSolver(BaseUnstructuredSolver):
+class NLSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
     """Nonlinear solver interface.
 
     This class provides a :term:`nonlinear model` sampling method and encapsulates
@@ -961,7 +952,7 @@ class StructuredSolver(BaseSolver):
         # Create a set of default parameters for the queries
         self._params = {}
 
-        # Add derived properties specific for this solver
+        # Add derived properties specific for this solver class
         self.derived_properties.update({'lower_noise', 'num_active_qubits', 'version', 'graph_id'})
 
     def __repr__(self):

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -1255,7 +1255,7 @@ class StructuredSolver(BaseSolver):
 
         Args:
             problem:
-                Tuple with linear/quadratic terms of the model and the offset.
+                A 3-tuple with linear/quadratic terms of the model and the offset.
 
             problem_type:
                 Problem type, one of the handled problem types by the solver.
@@ -1278,6 +1278,11 @@ class StructuredSolver(BaseSolver):
         Returns:
             Response in a future.
 
+        Note:
+            :meth:`.sample_problem` accepts the native problem formulation for a
+            solver, and for structured QPU solvers that's typically the Ising
+            form. Calling ``sample_problem()`` with the default arguments is
+            equivallent to calling :meth:`.sample_ising`.
         """
         linear, quadratic, offset = problem
         return self._sample(type_=problem_type, linear=linear, quadratic=quadratic,

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -593,10 +593,10 @@ class BQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
             from dimod import BinaryQuadraticModel
         except ImportError: # pragma: no cover
             raise RuntimeError(
-                "dimod package with support for DiscreteQuadraticModel required."
-                "Re-install the library with 'dqm' support.")
+                "dimod package with support for BinaryQuadraticModel required."
+                "Re-install the library with 'bqm' support.")
 
-        bqm = BinaryQuadraticModel.from_ising({0: 1}, {})
+        bqm = BinaryQuadraticModel.from_ising({}, {(0, 1): 1})
         params = {}
         try:
             params.update(time_limit=self.properties['minimum_time_limit'][0][1])
@@ -814,7 +814,7 @@ class CQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
                 "dimod package with support for ConstrainedQuadraticModel required."
                 "Re-install the library with 'cqm' support.")
 
-        cqm = ConstrainedQuadraticModel.from_bqm(dimod.BQM.from_ising({0: 1}, {}))
+        cqm = ConstrainedQuadraticModel.from_bqm(dimod.BQM.from_ising({}, {(0, 1): 1}))
 
         params = {}
         try:
@@ -921,7 +921,7 @@ class NLSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
                                "Re-install the library with 'nlm' support.")
 
         model = Model()
-        x = model.list(10)
+        x = model.list(3)
         model.minimize(x.sum())
 
         # note: minimum time limit is not exposed via properties, but value >0 is required
@@ -1348,7 +1348,7 @@ class StructuredSolver(BaseSolver):
         """A small binary quadratic problem accepted by the :meth:`.sample_problem`
         method, together with a set of required parameter values.
         """
-        problem = ({min(self.nodes): 0}, {}, 0.0)
+        problem = ({}, {min(self.edges): 1}, 0.0)
         params = {}
         return problem, params
 
@@ -1791,25 +1791,6 @@ class QCDLSolver(BaseUnstructuredSolver):
 
     def _encode_problem_for_upload(self, qcdl, **kwargs):
         return orjson.dumps(qcdl)
-
-    @property
-    def minimal_problem(self) -> tuple['dwave.optimization.Model', dict]:
-        """A small :class:`~dwave.optimization.Model` accepted by the
-        :meth:`.sample_problem` method, together with a set of required
-        parameter values.
-        """
-        try:
-            from dwave.optimization import Model
-        except ImportError: # pragma: no cover
-            raise RuntimeError("Can't sample from nonlinear model without dwave-optimization. "
-                               "Re-install the library with 'nlm' support.")
-
-        model = Model()
-        x = model.list(10)
-        model.minimize(x.sum())
-        params = {}
-
-        return model, params
 
     @property
     def minimal_problem(self) -> tuple[dict, dict]:

--- a/dwave/cloud/solver.py
+++ b/dwave/cloud/solver.py
@@ -234,6 +234,17 @@ class BaseSolver:
         """Encode and upload the specified problem."""
         raise NotImplementedError
 
+    @property
+    def minimal_problem(self) -> tuple[Any, dict]:
+        """A small problem accepted by the solver's :meth:`.sample_problem`,
+        together with a set of required parameter values.
+
+        Example:
+            problem, params = solver.minimal_problem
+            solver.sample_problem(problem, **params)
+        """
+        raise NotImplementedError
+
     # Derived properties
 
     @property
@@ -572,6 +583,28 @@ class BQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
     def _encode_problem_for_upload(self, bqm, **kwargs):
         return bqm.to_file()
 
+    @property
+    def minimal_problem(self) -> tuple['dimod.BinaryQuadraticModel', dict]:
+        """A small :class:`~dimod.BinaryQuadraticModel` accepted by the
+        :meth:`.sample_problem` method, together with a set of required
+        parameter values.
+        """
+        try:
+            from dimod import BinaryQuadraticModel
+        except ImportError: # pragma: no cover
+            raise RuntimeError(
+                "dimod package with support for DiscreteQuadraticModel required."
+                "Re-install the library with 'dqm' support.")
+
+        bqm = BinaryQuadraticModel.from_ising({0: 1}, {})
+        params = {}
+        try:
+            params.update(time_limit=self.properties['minimum_time_limit'][0][1])
+        except (KeyError, IndexError):
+            pass
+
+        return bqm, params
+
     def sample_bqm(self, bqm, label=None, **params):
         """Sample from the specified :term:`BQM`.
 
@@ -663,12 +696,38 @@ class DQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
     def _encode_problem_for_upload(self, dqm, **kwargs):
         return dqm.to_file()
 
+    @property
+    def minimal_problem(self) -> tuple['dimod.DiscreteQuadraticModel', dict]:
+        """A small :class:`~dimod.DiscreteQuadraticModel` accepted by the
+        :meth:`.sample_problem` method, together with a set of required
+        parameter values.
+        """
+        try:
+            from dimod import DiscreteQuadraticModel
+        except ImportError: # pragma: no cover
+            raise RuntimeError(
+                "dimod package with support for DiscreteQuadraticModel required."
+                "Re-install the library with 'dqm' support.")
+
+        dqm = DiscreteQuadraticModel()
+        u = dqm.add_variable(2)
+        v = dqm.add_variable(2)
+        dqm.set_quadratic(u, v, {(0, 1): 1})
+
+        params = {}
+        try:
+            params.update(time_limit=self.properties['minimum_time_limit'][0][1])
+        except (KeyError, IndexError):
+            pass
+
+        return dqm, params
+
     def sample_bqm(self, bqm, label=None, **params):
         """Use for testing only."""
 
         # to sample BQM problems, we need to convert them to DQM
         if isinstance(bqm, str):
-            # unless bqm already uploaded
+            # unless dqm already uploaded
             dqm = bqm
         else:
             dqm = self._bqm_to_dqm(bqm)
@@ -741,6 +800,29 @@ class CQMSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
 
     def _encode_problem_for_upload(self, cqm, **kwargs):
         return cqm.to_file()
+
+    @property
+    def minimal_problem(self) -> tuple['dimod.ConstrainedQuadraticModel', dict]:
+        """A small :class:`~dimod.ConstrainedQuadraticModel` accepted by the
+        :meth:`.sample_problem` method, together with a set of required
+        parameter values.
+        """
+        try:
+            from dimod import ConstrainedQuadraticModel
+        except ImportError: # pragma: no cover
+            raise RuntimeError(
+                "dimod package with support for ConstrainedQuadraticModel required."
+                "Re-install the library with 'cqm' support.")
+
+        cqm = ConstrainedQuadraticModel.from_bqm(dimod.BQM.from_ising({0: 1}, {}))
+
+        params = {}
+        try:
+            params.update(time_limit=self.properties['minimum_time_limit_s'])
+        except (KeyError, IndexError):
+            pass
+
+        return cqm, params
 
     def sample_bqm(self, bqm, label=None, **params):
         """Use for testing."""
@@ -825,6 +907,27 @@ class NLSolver(QuadraticUnstructuredSolverMixin, BaseUnstructuredSolver):
         encode_params = {k: v for k, v in kwargs.items()
                          if k in {'max_num_states', 'only_decision'}}
         return model.to_file(**encode_params)
+
+    @property
+    def minimal_problem(self) -> tuple['dwave.optimization.Model', dict]:
+        """A small :class:`~dwave.optimization.Model` accepted by the
+        :meth:`.sample_problem` method, together with a set of required
+        parameter values.
+        """
+        try:
+            from dwave.optimization import Model
+        except ImportError: # pragma: no cover
+            raise RuntimeError("Can't sample from nonlinear model without dwave-optimization. "
+                               "Re-install the library with 'nlm' support.")
+
+        model = Model()
+        x = model.list(10)
+        model.minimize(x.sum())
+
+        # note: minimum time limit is not exposed via properties, but value >0 is required
+        params = dict(time_limit=1)
+
+        return model, params
 
     def sample_bqm(self,
                    bqm: 'dimod.BQM',
@@ -1239,6 +1342,15 @@ class StructuredSolver(BaseSolver):
 
         return self._sample(problem_type, linear, quadratic, bqm.offset,
                             params, label=label, undirected_biases=True)
+
+    @property
+    def minimal_problem(self) -> tuple[tuple[dict, dict, float], dict]:
+        """A small binary quadratic problem accepted by the :meth:`.sample_problem`
+        method, together with a set of required parameter values.
+        """
+        problem = ({min(self.nodes): 0}, {}, 0.0)
+        params = {}
+        return problem, params
 
     def sample_problem(self,
                        problem: tuple[list | dict[int, float],
@@ -1681,8 +1793,29 @@ class QCDLSolver(BaseUnstructuredSolver):
         return orjson.dumps(qcdl)
 
     @property
-    def minimal_job(self) -> tuple[Any, dict]:
-        """Return a minimal QCDL circuit that can be submitted (and solved)."""
+    def minimal_problem(self) -> tuple['dwave.optimization.Model', dict]:
+        """A small :class:`~dwave.optimization.Model` accepted by the
+        :meth:`.sample_problem` method, together with a set of required
+        parameter values.
+        """
+        try:
+            from dwave.optimization import Model
+        except ImportError: # pragma: no cover
+            raise RuntimeError("Can't sample from nonlinear model without dwave-optimization. "
+                               "Re-install the library with 'nlm' support.")
+
+        model = Model()
+        x = model.list(10)
+        model.minimize(x.sum())
+        params = {}
+
+        return model, params
+
+    @property
+    def minimal_problem(self) -> tuple[dict, dict]:
+        """A small QCDL circuit accepted by the :meth:`.sample_problem` method,
+        together with a set of required parameter values.
+        """
         qcdl = {
             'program': {
                 'statements': [

--- a/releasenotes/notes/add-Solver.minimal_problem-798478b79196e16c.yaml
+++ b/releasenotes/notes/add-Solver.minimal_problem-798478b79196e16c.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Introduce ``Solver.minimal_problem``, a new solver property that returns a
+    minimal problem accepted by the solver, together with a set of parameter
+    values required to successfully submit the problem to SAPI.
+  - |
+    Expand the solver interface to include ``sample_problem()`` and
+    ``upload_problem()`` (previously available only on unstructured solvers).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -316,7 +316,7 @@ class TestCli(unittest.TestCase):
             # sampling method called on solver with correct params?
             solver = client.get_solver.return_value
             solver.sample_problem.assert_called_with(
-                ({3: 0}, {}, 0.0), label=label, **params)
+                problem=({3: 0}, {}, 0.0), label=label, **params)
 
             # verify output contains timing data
             self.assertIn('Wall clock time', result.output)
@@ -332,43 +332,53 @@ class TestCli(unittest.TestCase):
         profile = 'profile'
         client = 'qpu'
         solver = '{"qpu": true}'
-        biases = '[0]'
-        couplings = '{(0, 4): 1}'
+        biases = '{1: 0}'
+        couplings = '{(1, 2): 1}'
         num_reads = '10'
         label = 'label'
 
         with mock.patch('dwave.cloud.cli.Client') as m:
+            # mock returned solver
+            s = solver_object("qpu")
+            with mock.patch.object(s, "sample_ising") as sample_ising:
+                c = m.from_config.return_value
+                c.get_solver.return_value = s
 
-            runner = CliRunner()
-            with runner.isolated_filesystem():
-                touch(config_file)
-                result = runner.invoke(cli, ['sample',
-                                             config_file_option, config_file,
-                                             '--profile', profile,
-                                             '--client', client,
-                                             '--solver', solver,
-                                             '--label', label,
-                                             '-h', biases,
-                                             '-j', couplings,
-                                             '-n', num_reads])
+                runner = CliRunner()
+                with runner.isolated_filesystem():
+                    touch(config_file)
+                    result = runner.invoke(cli, ['sample',
+                                                config_file_option, config_file,
+                                                '--profile', profile,
+                                                '--client', client,
+                                                '--solver', solver,
+                                                '--label', label,
+                                                '-h', biases,
+                                                '-j', couplings,
+                                                '-n', num_reads])
 
-            # proper arguments passed to Client.from_config?
-            m.from_config.assert_called_with(
-                config_file=config_file, profile=profile,
-                endpoint=None, region=None,
-                client=client, solver=solver)
+                # proper arguments passed to Client.from_config?
+                expected_config = dict(
+                    config_file=config_file, profile=profile,
+                    endpoint=None, region=None,
+                    client=client, solver=solver)
+                call = m.from_config.call_args.kwargs
+                self.assertEqual(call, expected_config)
 
-            # get solver called?
-            c = m.from_config.return_value
-            c.get_solver.assert_called_with()
+                m.from_config.assert_called_with(
+                    config_file=config_file, profile=profile,
+                    endpoint=None, region=None,
+                    client=client, solver=solver)
 
-            # sampling method called on solver?
-            s = c.get_solver.return_value
-            s.sample_problem.assert_called_with(
-                ({0: 0}, {(0, 4): 1}, 0.0), num_reads=10, label=label)
+                # get solver called?
+                c.get_solver.assert_called_with()
 
-            # verify output contains timing data
-            self.assertIn('Wall clock time', result.output)
+                # sampling method called on solver?
+                sample_ising.assert_called_with(
+                    {1: 0}, {(1, 2): 1}, 0.0, num_reads=10, label=label)
+
+                # verify output contains timing data
+                self.assertIn('Wall clock time', result.output)
 
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,11 +18,10 @@ import os
 import tempfile
 import unittest
 import warnings
-from functools import partial, wraps
+from functools import wraps
 from pathlib import Path
 from unittest import mock
 
-import diskcache
 from click.testing import CliRunner
 from parameterized import parameterized
 
@@ -287,7 +286,7 @@ class TestCli(unittest.TestCase):
         with mock.patch('dwave.cloud.cli.Client') as m:
             # mock returned solver
             client = m.from_config.return_value
-            client.get_solver.return_value.nodes = [5, 7, 3]
+            client.get_solver.return_value.minimal_problem = (({3: 0}, {}, 0.0), {})
 
             runner = CliRunner()
             with runner.isolated_filesystem():
@@ -316,8 +315,8 @@ class TestCli(unittest.TestCase):
 
             # sampling method called on solver with correct params?
             solver = client.get_solver.return_value
-            solver.sample_ising.assert_called_with(
-                {3: 0}, {}, label=label, **params)
+            solver.sample_problem.assert_called_with(
+                ({3: 0}, {}, 0.0), label=label, **params)
 
             # verify output contains timing data
             self.assertIn('Wall clock time', result.output)
@@ -365,8 +364,8 @@ class TestCli(unittest.TestCase):
 
             # sampling method called on solver?
             s = c.get_solver.return_value
-            s.sample_ising.assert_called_with(
-                {0: 0}, {(0, 4): 1}, num_reads=10, label=label)
+            s.sample_problem.assert_called_with(
+                ({0: 0}, {(0, 4): 1}, 0.0), num_reads=10, label=label)
 
             # verify output contains timing data
             self.assertIn('Wall clock time', result.output)

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -104,6 +104,33 @@ class MockSubmissionBase(_QueryTest):
 class MockSubmissionBaseTests(MockSubmissionBase):
     """Test connecting and some related failure modes."""
 
+    def test_submit_minimal_problem_smoke(self):
+        """Get a minimal problem for a solver and submit it."""
+
+        # each thread can have its instance of a session because
+        # the mocked responses are stateless
+        def create_mock_session(client):
+            session = mock.Mock()
+            session.post = lambda path, **kwargs: choose_reply(path, {
+                'problems/': [self.sapi.complete_no_answer_reply(id='123')]})
+            session.get = lambda path, **kwargs: choose_reply(path, {
+                'problems/123/': self.sapi.complete_reply(id='123')})
+            return session
+
+        with mock.patch.object(Client, 'create_session', create_mock_session):
+            with Client(**self.config) as client:
+                solver = Solver(client, self.sapi.solver.data)
+
+                problem, params = solver.minimal_problem
+                linear, quadratic, offset = problem
+
+                self.assertEqual(linear, {min(solver.nodes): 0})
+                self.assertEqual(offset, 0.0)
+
+                results = solver.sample_problem(problem, **params)
+                results.result()
+                self.assertGreater(len(results.num_occurrences), 0)
+
     def test_submit_null_reply(self):
         """Get an error when the server's response is incomplete."""
 

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -124,7 +124,8 @@ class MockSubmissionBaseTests(MockSubmissionBase):
                 problem, params = solver.minimal_problem
                 linear, quadratic, offset = problem
 
-                self.assertEqual(linear, {min(solver.nodes): 0})
+                self.assertEqual(linear, {})
+                self.assertEqual(quadratic, {min(solver.edges): 1})
                 self.assertEqual(offset, 0.0)
 
                 results = solver.sample_problem(problem, **params)

--- a/tests/test_mock_submission.py
+++ b/tests/test_mock_submission.py
@@ -40,7 +40,7 @@ from dwave.cloud.exceptions import (
     SolverFailureError, CanceledFutureError, SolverError,
     InvalidAPIResponseError, UseAfterCloseError)
 from dwave.cloud.solver import Solver
-from dwave.cloud.utils.qubo import evaluate_ising
+from dwave.cloud.utils.qubo import evaluate_ising, reformat_qubo_as_ising
 from dwave.cloud.utils.time import utcrel
 
 from tests.api.mocks import StructuredSapiMockResponses, choose_reply
@@ -125,6 +125,10 @@ class MockSubmissionBaseTests(MockSubmissionBase):
                 with self.assertRaises(InvalidAPIResponseError):
                     results.samples
 
+                results = solver.sample_problem((linear, quadratic, 0.0))
+                with self.assertRaises(InvalidAPIResponseError):
+                    results.samples
+
     def test_submit_ising_ok_reply(self):
         """Handle a normal query and response."""
 
@@ -144,8 +148,11 @@ class MockSubmissionBaseTests(MockSubmissionBase):
 
                 linear, quadratic = self.sapi.problem
                 params = dict(num_reads=100)
-                results = solver.sample_ising(linear, quadratic, **params)
 
+                results = solver.sample_ising(linear, quadratic, **params)
+                self._check(results, linear, quadratic, **params)
+
+                results = solver.sample_problem((linear, quadratic, 0.0), **params)
                 self._check(results, linear, quadratic, **params)
 
     @unittest.skipUnless(dimod, "dimod required for 'Solver.sample_bqm'")
@@ -168,10 +175,12 @@ class MockSubmissionBaseTests(MockSubmissionBase):
 
                 h, J = self.sapi.problem
                 bqm = dimod.BinaryQuadraticModel.from_ising(h, J)
-
                 params = dict(num_reads=100)
-                results = solver.sample_bqm(bqm, **params)
 
+                results = solver.sample_bqm(bqm, **params)
+                self._check(results, h, J, **params)
+
+                results = solver.sample_problem((h, J, 0), problem_type='ising', **params)
                 self._check(results, h, J, **params)
 
     def test_submit_qubo_ok_reply(self):
@@ -204,6 +213,13 @@ class MockSubmissionBaseTests(MockSubmissionBase):
                 params = dict(num_reads=100)
 
                 results = solver.sample_qubo(qubo, offset, **params)
+
+                # make sure energies are correct in raw results
+                for energy, sample in zip(results.energies, results.samples):
+                    self.assertEqual(energy, evaluate_ising({}, qubo, sample, offset=offset))
+
+                linear, quadratic = reformat_qubo_as_ising(qubo)
+                results = solver.sample_problem((linear, quadratic, offset), problem_type='qubo', **params)
 
                 # make sure energies are correct in raw results
                 for energy, sample in zip(results.energies, results.samples):

--- a/tests/test_mock_unstructured_submission.py
+++ b/tests/test_mock_unstructured_submission.py
@@ -152,6 +152,13 @@ class TestUnstructuredSolver(unittest.TestCase):
                 numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
                 numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
 
+                # universal sample_problem interface
+                fut = solver.sample_problem(bqm)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
+                numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
+                numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
+
                 # ising sampling
                 lin, quad, _ = bqm.to_ising()
                 ss = dimod.ExactSolver().sample_ising(lin, quad)
@@ -227,6 +234,11 @@ class TestUnstructuredSolver(unittest.TestCase):
                 numpy.testing.assert_array_equal(fut.sampleset, ss)
                 numpy.testing.assert_array_equal(fut.problem_type, problem_type)
 
+                # universal sample_problem interface
+                fut = solver.sample_problem(cqm)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.problem_type, problem_type)
+
     def test_sample_dqm_smoke_test(self):
         """Construction of and sampling from an unstructured DQM solver works."""
 
@@ -270,6 +282,11 @@ class TestUnstructuredSolver(unittest.TestCase):
 
                 # verify decoding works
                 fut = solver.sample_dqm(dqm)
+                numpy.testing.assert_array_equal(fut.sampleset, ss)
+                numpy.testing.assert_array_equal(fut.problem_type, problem_type)
+
+                # universal sample_problem interface
+                fut = solver.sample_problem(dqm)
                 numpy.testing.assert_array_equal(fut.sampleset, ss)
                 numpy.testing.assert_array_equal(fut.problem_type, problem_type)
 
@@ -384,7 +401,12 @@ class TestNLSolver(unittest.TestCase):
         setattr(session, '__exit__', mock.Mock())
         session.__enter__.return_value = session
         session.__exit__.return_value = None
-        session.get.return_value.iter_content.return_value = iter([mock_answer_data])
+        # make sure each get request gets a fresh iterator over mock answer data
+        def mock_answer(*args, **kwargs):
+            response = mock.Mock()
+            response.iter_content.return_value = iter([mock_answer_data])
+            return response
+        session.get.side_effect = mock_answer
 
         # mock the upload worker on client only, still testing the solver upload path
         mock_problem_id = 'mock-problem-id'
@@ -395,7 +417,7 @@ class TestNLSolver(unittest.TestCase):
 
         # construct a functional solver by mocking client and api response data
         with mock.patch.multiple(Client, create_session=lambda self: session,
-                                 upload_problem_encoded=mock_upload):
+                                 upload_problem_encoded=mock_upload) as mocker:
             with Client(endpoint='endpoint', token='token') as client:
                 solver = NLSolver(client, hybrid_nl_solver_data())
 
@@ -411,6 +433,14 @@ class TestNLSolver(unittest.TestCase):
 
                 # verify decoding works
                 fut = solver.sample_nlm(model, upload_params=upload_params)
+                self.assertEqual(fut.problem_type, problem_type)
+                self.assertEqual(fut.timing, timing_info)
+                self.assertEqual(fut.answer_data.read(), mock_answer_data)
+
+                session.get.reset_mock()
+
+                # universal sample_problem interface
+                fut = solver.sample_problem(model, upload_params=upload_params)
                 self.assertEqual(fut.problem_type, problem_type)
                 self.assertEqual(fut.timing, timing_info)
                 self.assertEqual(fut.answer_data.read(), mock_answer_data)
@@ -459,7 +489,12 @@ class TestQCDLSolver(unittest.TestCase):
         setattr(session, '__exit__', mock.Mock())
         session.__enter__.return_value = session
         session.__exit__.return_value = None
-        session.get.return_value.iter_content.return_value = iter([mock_answer_data])
+        # make sure each get request gets a fresh iterator over mock answer data
+        def mock_answer(*args, **kwargs):
+            response = mock.Mock()
+            response.iter_content.return_value = iter([mock_answer_data])
+            return response
+        session.get.side_effect = mock_answer
 
         # mock the upload worker on client only, still testing the solver upload path
         mock_problem_id = 'mock-problem-id'
@@ -500,6 +535,12 @@ class TestQCDLSolver(unittest.TestCase):
 
                 # verify decoding works
                 fut = solver.sample_qcdl(qcdl, num_shots=num_shots)
+                self.assertEqual(fut.problem_type, problem_type)
+                self.assertEqual(fut.timing, timing_info)
+                self.assertEqual(fut.answer_data.read(), mock_answer_data)
+
+                # universal sample_problem interface
+                fut = solver.sample_problem(qcdl, num_shots=num_shots)
                 self.assertEqual(fut.problem_type, problem_type)
                 self.assertEqual(fut.timing, timing_info)
                 self.assertEqual(fut.answer_data.read(), mock_answer_data)

--- a/tests/test_mock_unstructured_submission.py
+++ b/tests/test_mock_unstructured_submission.py
@@ -30,7 +30,9 @@ from dwave.cloud.solver import (
     BQMSolver, CQMSolver, DQMSolver, NLSolver, QCDLSolver)
 from dwave.cloud.concurrency import Present
 from dwave.cloud.testing.mocks import (
-    qpu_pegasus_solver_data, hybrid_nl_solver_data, qcdl_solver_data)
+    hybrid_bqm_solver_data, hybrid_cqm_solver_data, hybrid_dqm_solver_data,
+    hybrid_nl_solver_data, qcdl_solver_data, qpu_pegasus_solver_data,
+)
 
 from tests.api.mocks import choose_reply
 
@@ -44,18 +46,6 @@ try:
 except ImportError:
     NLModel = None
 
-
-def unstructured_solver_data(problem_type='bqm', solver_name='test-unstructured-solver'):
-    return {
-        "properties": {
-            "supported_problem_types": [problem_type],
-            "parameters": {"num_reads": "Number of samples to return."}
-        },
-        "identity": {
-            "name": solver_name,
-        },
-        "description": "A test unstructured solver"
-    }
 
 def complete_reply_bq(sampleset, id_="problem-id", type_='bqm', label=None):
     """Reply with the sampleset as a solution."""
@@ -128,10 +118,10 @@ class TestUnstructuredSolver(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda self: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = BQMSolver(client, unstructured_solver_data())
+                solver = BQMSolver(client, hybrid_bqm_solver_data())
 
                 # make sure this still works
-                _ = UnstructuredSolver(client, unstructured_solver_data())
+                _ = UnstructuredSolver(client, hybrid_bqm_solver_data())
 
                 # direct bqm sampling
                 ss = dimod.ExactSolver().sample(bqm)
@@ -158,6 +148,11 @@ class TestUnstructuredSolver(unittest.TestCase):
                 numpy.testing.assert_array_equal(fut.samples, ss.record.sample)
                 numpy.testing.assert_array_equal(fut.energies, ss.record.energy)
                 numpy.testing.assert_array_equal(fut.num_occurrences, ss.record.num_occurrences)
+
+                # minimal_problem smoke
+                problem, params = solver.minimal_problem
+                self.assertIsInstance(problem, dimod.BQM)
+                self.assertIn("time_limit", params)
 
                 # ising sampling
                 lin, quad, _ = bqm.to_ising()
@@ -221,7 +216,7 @@ class TestUnstructuredSolver(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda self: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = CQMSolver(client, unstructured_solver_data(problem_type=problem_type))
+                solver = CQMSolver(client, hybrid_cqm_solver_data())
 
                 # use bqm for mock response (for now)
                 ss = dimod.ExactSolver().sample(dimod.BQM.empty('SPIN'))
@@ -238,6 +233,11 @@ class TestUnstructuredSolver(unittest.TestCase):
                 fut = solver.sample_problem(cqm)
                 numpy.testing.assert_array_equal(fut.sampleset, ss)
                 numpy.testing.assert_array_equal(fut.problem_type, problem_type)
+
+                # minimal_problem smoke
+                problem, params = solver.minimal_problem
+                self.assertIsInstance(problem, dimod.CQM)
+                self.assertIn("time_limit", params)
 
     def test_sample_dqm_smoke_test(self):
         """Construction of and sampling from an unstructured DQM solver works."""
@@ -272,7 +272,7 @@ class TestUnstructuredSolver(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda self: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = DQMSolver(client, unstructured_solver_data(problem_type=problem_type))
+                solver = DQMSolver(client, hybrid_dqm_solver_data())
 
                 # use bqm for mock response (for now)
                 ss = dimod.ExactSolver().sample(dimod.BQM.empty('SPIN'))
@@ -289,6 +289,11 @@ class TestUnstructuredSolver(unittest.TestCase):
                 fut = solver.sample_problem(dqm)
                 numpy.testing.assert_array_equal(fut.sampleset, ss)
                 numpy.testing.assert_array_equal(fut.problem_type, problem_type)
+
+                # minimal_problem smoke
+                problem, params = solver.minimal_problem
+                self.assertIsInstance(problem, dimod.DQM)
+                self.assertIn("time_limit", params)
 
     def test_upload_failure(self):
         """Submit should gracefully fail if upload as part of submit fails."""
@@ -308,7 +313,7 @@ class TestUnstructuredSolver(unittest.TestCase):
         with mock.patch.object(Client, 'create_session', lambda self: session):
             with Client(endpoint='endpoint', token='token') as client:
                 with mock.patch.object(BaseUnstructuredSolver, 'upload_problem', mock_upload):
-                    solver = UnstructuredSolver(client, unstructured_solver_data())
+                    solver = UnstructuredSolver(client, hybrid_bqm_solver_data())
 
                     # direct bqm sampling
                     ss = dimod.ExactSolver().sample(bqm)
@@ -338,7 +343,7 @@ class TestUnstructuredSolver(unittest.TestCase):
         with mock.patch.object(Client, 'create_session', lambda self: session):
             with Client(endpoint='endpoint', token='token') as client:
                 with mock.patch.object(BaseUnstructuredSolver, 'upload_problem', mock_upload):
-                    solver = BQMSolver(client, unstructured_solver_data())
+                    solver = BQMSolver(client, hybrid_bqm_solver_data())
 
                     futs = [solver.sample_bqm(bqm) for _ in range(100)]
 
@@ -445,6 +450,11 @@ class TestNLSolver(unittest.TestCase):
                 self.assertEqual(fut.timing, timing_info)
                 self.assertEqual(fut.answer_data.read(), mock_answer_data)
 
+                # minimal_problem smoke
+                problem, params = solver.minimal_problem
+                self.assertIsInstance(problem, NLModel)
+                self.assertIn("time_limit", params)
+
 
 class TestQCDLSolver(unittest.TestCase):
 
@@ -545,6 +555,11 @@ class TestQCDLSolver(unittest.TestCase):
                 self.assertEqual(fut.timing, timing_info)
                 self.assertEqual(fut.answer_data.read(), mock_answer_data)
 
+                # minimal_problem smoke
+                problem, params = solver.minimal_problem
+                self.assertIsInstance(problem, dict)
+                self.assertIsInstance(params, dict)
+
 
 class TestProblemLabel(unittest.TestCase):
 
@@ -599,7 +614,7 @@ class TestProblemLabel(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda self: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = BQMSolver(client, unstructured_solver_data())
+                solver = BQMSolver(client, hybrid_bqm_solver_data())
 
                 problems = [("sample_ising", (bqm.linear, bqm.quadratic)),
                             ("sample_qubo", (bqm.quadratic,)),
@@ -638,7 +653,7 @@ class TestProblemLabel(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda self: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = BQMSolver(client, unstructured_solver_data())
+                solver = BQMSolver(client, hybrid_bqm_solver_data())
 
                 # construct mock response
                 ss = dimod.ExactSolver().sample(bqm)
@@ -686,7 +701,7 @@ class TestAnswerDownloadFromBinaryRef(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda _: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = CQMSolver(client, unstructured_solver_data(problem_type=problem_type))
+                solver = CQMSolver(client, hybrid_cqm_solver_data())
 
                 # solver has to support binary-ref
                 solver._handled_encoding_formats.add('binary-ref')
@@ -768,7 +783,7 @@ class TestSerialization(unittest.TestCase):
         with mock.patch.multiple(Client, create_session=lambda self: session,
                                  upload_problem_encoded=mock_upload):
             with Client(endpoint='endpoint', token='token') as client:
-                solver = BQMSolver(client, unstructured_solver_data())
+                solver = BQMSolver(client, hybrid_bqm_solver_data())
 
                 problems = [("sample_ising", (bqm.linear, bqm.quadratic)),
                             ("sample_qubo", (bqm.quadratic,)),

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -271,6 +271,28 @@ class Submission(_QueryTest):
             numpy.testing.assert_array_almost_equal(
                 bqm.energies(sampleset), sampleset.record.energy)
 
+    def test_submit_minimal_problem(self):
+        """Submit a minimal problem using the standard interface."""
+
+        with Client(**config) as client:
+            solver = client.get_solver()
+
+            problem, params = solver.minimal_problem
+            params.update(num_reads=100)
+
+            response = solver.sample_problem(problem, **params)
+            sampleset = response.sampleset
+
+            self.assertEqual(sampleset.wait_id(), sampleset.info['problem_id'])
+            self.assertEqual(response.id, sampleset.info['problem_id'])
+
+            # Did we get the right number of samples?
+            self.assertEqual(100, sum(response.num_occurrences))
+
+            # Make sure the number of occurrences and energies are all correct
+            numpy.testing.assert_array_almost_equal(
+                dimod.BQM.from_ising(*problem).energies(sampleset), sampleset.record.energy)
+
     @unittest.skipUnless(dimod, "dimod required for 'Solver.sample_bqm'")
     def test_all_sampling_methods_are_consistent(self):
         """Submit Ising/QUBO/BQM and verify the results are consistent."""
@@ -516,6 +538,33 @@ class UnstructuredSubmission(unittest.TestCase):
 
             model.states.from_file(f.answer_data)
             self.assertGreater(model.states.size(), 0)
+
+    @parameterized.expand([
+        ("bqm", ),
+        ("cqm", ),
+        ("dqm", ),
+        ("nl", ),
+        # TODO: add after QCDL deployed to prod
+        #("qcdl", ),
+    ])
+    def test_sample_minimal_problem(self, problem_type):
+
+        # use default config; skip loading config file, assume token in env
+        with Client.from_config(config_file=False) as client:
+            solver = client.get_solver(supported_problem_types__contains=problem_type)
+            problem, params = solver.minimal_problem
+
+            f = solver.sample_problem(problem, **params)
+            f.result()
+
+            self.assertEqual(f.problem_type, problem_type)
+            if f.answer_data is None:
+                # bqm/cqm/dqm
+                self.assertIsInstance(f.sampleset, dimod.SampleSet)
+                self.assertEqual(f.sampleset.info.get('problem_id'), f.wait_id())
+            else:
+                # nlm, qcdl
+                self.assertGreater(len(f.answer_data.read()), 0)
 
 
 @unittest.skipUnless(config, "No live server configuration available.")


### PR DESCRIPTION
In this PR we:
- redefine base solvers and their subclasses a bit; now `minimal_problem`, `sample_problem` and `upload_problem` are universally defined for all solvers.
- add support for pinging any existing solver, without the need to manually specify required parameters