### PR TITLE
Add region CLI

### DIFF
--- a/dwave/cloud/api/models.py
+++ b/dwave/cloud/api/models.py
@@ -234,7 +234,7 @@ class ProblemCancelError(BatchItemError):
 
 
 # region info on metadata api
-class Region(BaseModel):
+class Region(_DictMixin, BaseModel):
     code: str
     name: str
     endpoint: str

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -1316,3 +1316,47 @@ def cache_purge(*, config_file, profile, output):
                 shutil.rmtree(path)
 
     output("Cache purged.")
+
+
+@cli.group()
+def region():
+    """Get available regions."""
+
+
+@region.command(name='ls')
+@config_file_options()
+@click.option('--metadata-api-endpoint', metavar='URL', type=str, default=None,
+              help='Metadata API endpoint [default: from config]')
+@click.option('--verbose', '-v', default=False, is_flag=True,
+              help='Increase output verbosity')
+@json_output
+@raw_output
+@standardized_output
+def region_list(*, config_file, profile, metadata_api_endpoint, verbose,
+                json_output, raw_output, output):
+    """List regions."""
+
+    config = validate_config_v1(load_config(config_file=config_file, profile=profile))
+
+    if metadata_api_endpoint:
+        config.metadata_api_endpoint = metadata_api_endpoint
+
+    if verbose:
+        output("Using Metadata API endpoint: {metadata_api_endpoint}",
+            metadata_api_endpoint=config.metadata_api_endpoint)
+
+    regions = get_regions(config)
+
+    if verbose:
+        output("Retrieved {num_regions} regions.\n", num_regions=len(regions))
+
+    if json_output or raw_output:
+        rs = [r.dict() for r in regions]
+        output("{regions}", regions=rs, raw=orjson.dumps(rs))
+    else:
+        # ~YAML output
+        for region in regions:
+            output("Region: {name}", name=region.name)
+            output("  Code: {code}", code=region.code)
+            output("  Endpoint: {endpoint}", endpoint=region.endpoint)
+            output()

--- a/dwave/cloud/cli.py
+++ b/dwave/cloud/cli.py
@@ -95,10 +95,10 @@ def config_file_options(exists=True):
 
 
 def solver_options(fn):
-    """Decorate `fn` with `--client` and `--solver` options."""
+    """Decorate `fn` with `--client`/`-c` and `--solver`/`-s` options."""
 
     fn = click.option(
-        '--client', 'client_type', default=None,
+        '--client', '-c', 'client_type', default=None,
         type=click.Choice(['base', 'qpu', 'sw', 'hybrid'], case_sensitive=False),
         help='Client type used [default: from config]')(fn)
     fn = click.option(

--- a/releasenotes/notes/add-cli-region-ls-ba02a59156c14df6.yaml
+++ b/releasenotes/notes/add-cli-region-ls-ba02a59156c14df6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``dwave region ls`` CLI command to list available regions.

--- a/releasenotes/notes/cli-add-shortopt-client-1be554a5e2774d17.yaml
+++ b/releasenotes/notes/cli-add-shortopt-client-1be554a5e2774d17.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add CLI flag ``-c`` as an alias for ``--client``.
+
+    Note that ``-c`` (previously short for ``--config-file``) was deprecated in
+    0.8.5, and removed in 0.10.0, so that it could be repurposed as a short form
+    of ``--client``.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from functools import wraps
 from pathlib import Path
 from unittest import mock
 
+import orjson
 from click.testing import CliRunner
 from parameterized import parameterized
 
@@ -30,7 +31,7 @@ from dwave.cloud.config import load_config
 from dwave.cloud.config.models import validate_config_v1
 from dwave.cloud.testing import isolated_environ
 from dwave.cloud.auth.creds import Credentials, CREDS_FILENAME
-from dwave.cloud.api.models import LeapProject
+from dwave.cloud.api.models import LeapProject, Region
 from dwave.cloud.api.resources import Regions
 
 from tests import config, test_config_path, test_config_profile
@@ -776,12 +777,101 @@ class TestCacheCli(unittest.TestCase):
                 self.assertIn(str(creds_path), result.output)
 
 
+class TestRegionCli(unittest.TestCase):
+
+    def setUp(self):
+        self.env = isolated_environ(empty=True)
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+
+    def test_region_ls(self):
+        config_file = 'dwave.conf'
+        profile = 'profile'
+        metadata_api_endpoint = 'https://metadata'
+        regions = [Region(code='aaa', name='A', endpoint='https://a'),
+                   Region(code='bbb', name='B', endpoint='https://b')]
+
+        with mock.patch('dwave.cloud.cli.get_regions', return_value=regions) as m:
+            runner = CliRunner()
+
+            with self.subTest("default call"):
+                with runner.isolated_filesystem():
+                    touch(config_file)
+
+                    result = runner.invoke(cli, ['region', 'ls',
+                                                '--config-file', config_file])
+
+                # verify default metadata api used
+                m.assert_called_once()
+                config = m.call_args_list[0].args[0]
+                self.assertIn('/metadata/v', config.metadata_api_endpoint)
+
+                # verify exit code and stdout printout
+                self.assertEqual(result.exit_code, 0)
+                self.assertEqual(result.output.count('Region:'), 2)
+                self.assertIn('Region: A', result.output)
+                self.assertIn('Region: B', result.output)
+
+            m.reset_mock()
+
+            with self.subTest("use metadata api from config"):
+                with runner.isolated_filesystem():
+                    # create config
+                    with open(config_file, 'w') as fp:
+                        fp.write("\n".join([
+                            f"[{profile}]",
+                            f"metadata_api_endpoint = {metadata_api_endpoint}"]))
+
+                    result = runner.invoke(cli, ['region', 'ls',
+                                                '--config-file', config_file,
+                                                '--profile', profile])
+
+                m.assert_called_once()
+                config = m.call_args_list[0].args[0]
+                self.assertEqual(config.metadata_api_endpoint, metadata_api_endpoint)
+
+            m.reset_mock()
+
+            with self.subTest("use metadata api from command line"):
+                with runner.isolated_filesystem():
+                    touch(config_file)
+
+                    result = runner.invoke(cli, ['region', 'ls',
+                                                '--config-file', config_file,
+                                                '--metadata-api-endpoint', metadata_api_endpoint])
+
+                m.assert_called_once()
+                config = m.call_args_list[0].args[0]
+                self.assertEqual(config.metadata_api_endpoint, metadata_api_endpoint)
+
+            with self.subTest("--raw output"):
+                with runner.isolated_filesystem():
+                    touch(config_file)
+
+                    result = runner.invoke(cli, ['region', 'ls',
+                                                '--config-file', config_file,
+                                                '--raw'])
+
+                rs = orjson.dumps([r.dict() for r in regions]).decode('ascii')
+                self.assertEqual(result.output.strip(), rs)
+
+
+
 @unittest.skipUnless(config, "No live server configuration available.")
 class TestCliLive(unittest.TestCase):
 
     def test_ping(self):
         runner = CliRunner()
         result = runner.invoke(cli, ['ping',
+                                     '--config-file', test_config_path,
+                                     '--profile', test_config_profile])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_region_ls(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ['region', 'ls',
                                      '--config-file', test_config_path,
                                      '--profile', test_config_profile])
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Close #716.

```
$ dwave region ls --help
Usage: dwave region ls [OPTIONS]

  List regions.

Options:
  -p, --profile TEXT           Connection profile (section) name
  -f, --config-file FILE       Configuration file path
  --metadata-api-endpoint URL  Metadata API endpoint [default: from config]
  -v, --verbose                Increase output verbosity
  --json                       JSON output
  --raw                        Raw output
  --help                       Show this message and exit.
```

#### AI Generation Disclosure

No AI tools used